### PR TITLE
Add support for running queries with chunked responses

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -114,7 +114,7 @@ func TestIntegration_LargeQuery(t *testing.T) {
 	stmt, err := tx.Prepare("INSERT INTO test(n) VALUES(?)")
 	require.NoError(t, err)
 
-	for i := 0; i < 255; i++ {
+	for i := 0; i < 512; i++ {
 		_, err = stmt.Exec(int64(i))
 		require.NoError(t, err)
 	}
@@ -134,16 +134,20 @@ func TestIntegration_LargeQuery(t *testing.T) {
 
 	assert.Equal(t, []string{"n"}, columns)
 
+	count := 0
 	for i := 0; rows.Next(); i++ {
 		var n int64
 
 		require.NoError(t, rows.Scan(&n))
 
 		assert.Equal(t, int64(i), n)
+		count++
 	}
 
 	require.NoError(t, rows.Err())
 	require.NoError(t, rows.Close())
+
+	assert.Equal(t, count, 512)
 
 	require.NoError(t, tx.Rollback())
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -63,6 +63,11 @@ func (c *Client) Call(ctx context.Context, request, response *Message) error {
 	return nil
 }
 
+// More is used when a request maps to multiple responses.
+func (c *Client) More(ctx context.Context, response *Message) error {
+	return c.recv(response)
+}
+
 // Close the client connection.
 func (c *Client) Close() error {
 	c.log(bindings.LogInfo, "closing client")

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -22,3 +22,7 @@ type ErrRequest struct {
 func (e ErrRequest) Error() string {
 	return fmt.Sprintf("%s (%d)", e.Description, e.Code)
 }
+
+// ErrRowsPart is returned when the first batch of a multi-response result
+// batch is done.
+var ErrRowsPart = fmt.Errorf("not all rows were returned in this response")

--- a/internal/client/message.go
+++ b/internal/client/message.go
@@ -484,6 +484,11 @@ func (r *Rows) Next(dest []driver.Value) error {
 	for i := 0; i < headerSize; i++ {
 		slot := r.message.getUint8()
 
+		if slot == 0xee {
+			// More rows are available.
+			return ErrRowsPart
+		}
+
 		if slot == 0xff {
 			// Rows EOF marker
 			return io.EOF


### PR DESCRIPTION
To reduce latency the dqlite server now sends only a certain amount of rows data
in each query response, so the client needs to read multiple responses.