### PR TITLE
fix corner case of scanning for column types and encountering EOF

### DIFF
--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -523,11 +523,17 @@ func (r *Rows) columnTypes(save bool) ([]uint8, error) {
 
 		if slot == 0xee {
 			// More rows are available.
+			if save {
+				r.message.bufferForGet().Advance(-(i + 1))
+			}
 			return nil, ErrRowsPart
 		}
 
 		if slot == 0xff {
 			// Rows EOF marker
+			if save {
+				r.message.bufferForGet().Advance(-(i + 1))
+			}
 			return nil, io.EOF
 		}
 
@@ -548,7 +554,7 @@ func (r *Rows) columnTypes(save bool) ([]uint8, error) {
 		types[index] = slot >> 4
 	}
 	if save {
-	    r.message.bufferForGet().Advance(-headerSize)
+		r.message.bufferForGet().Advance(-headerSize)
 	}
 	return types, nil
 }


### PR DESCRIPTION
A fix for my previous feature enhancement (discovered thanks to sqlalchemy's thrashings...)

The non-destructive reads were not resetting when encountering an EOF, so this resets accordingly under that condition. 