### PR TITLE
use go routines to have simultaneous server requests; first one wins

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -106,7 +106,7 @@ func TestClient_Transfer(t *testing.T) {
 	node1, cleanup := newNode(t)
 	defer cleanup()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	cli, err := client.New(ctx, node1.BindAddress())
@@ -133,7 +133,6 @@ func TestClient_Transfer(t *testing.T) {
 	leader, err = cli.Leader(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, leader.ID, uint64(2))
-
 }
 
 func newNode(t *testing.T) (*dqlite.Node, func()) {

--- a/client/leader_test.go
+++ b/client/leader_test.go
@@ -31,7 +31,7 @@ func TestMembership(t *testing.T) {
 		defer node.Close()
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	store := client.NewInmemNodeStore()

--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -197,6 +197,14 @@ func (s *Node) Recover(cluster []protocol.NodeInfo) error {
 	return nil
 }
 
+// GenerateID generates a unique ID for a server.
+func GenerateID(address string) uint64 {
+	caddress := C.CString(address)
+	defer C.free(unsafe.Pointer(caddress))
+	id := C.dqlite_generate_node_id(caddress)
+	return uint64(id)
+}
+
 // Extract the underlying socket from a connection.
 func connToSocket(conn net.Conn) (C.int, error) {
 	file, err := conn.(fileConn).File()

--- a/node.go
+++ b/node.go
@@ -118,6 +118,16 @@ func (s *Node) Close() error {
 	return nil
 }
 
+// BootstrapID is a magic ID that should be used for the fist node in a
+// cluster. Alternatively ID 1 can be used as well.
+const BootstrapID = 0x2dc171858c3155be
+
+// GenerateID generates a unique ID for a new node, based on a hash of its
+// address and the current time.
+func GenerateID(address string) uint64 {
+	return bindings.GenerateID(address)
+}
+
 // Create a options object with sane defaults.
 func defaultOptions() *options {
 	return &options{


### PR DESCRIPTION
When trying to connect to the leader of the cluster, the client needs to try every node of the cluster until it finds the leader. This patch tries all nodes simultaneously to avoid spinning on servers that don't respond.