### PR TITLE
Add driver connection options

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -106,7 +106,7 @@ func TestClient_Transfer(t *testing.T) {
 	node1, cleanup := newNode(t)
 	defer cleanup()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	cli, err := client.New(ctx, node1.BindAddress())

--- a/cmd/dqlite-demo/cluster.go
+++ b/cmd/dqlite-demo/cluster.go
@@ -20,12 +20,14 @@ var (
 
 // Return a cluster nodes command.
 func newCluster() *cobra.Command {
+	var cluster *[]string
+
 	cmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "display cluster nodes.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := getLeader(defaultCluster)
+			client, err := getLeader(*cluster)
 			if err != nil {
 				return errors.Wrap(err, "can't connect to cluster leader")
 			}
@@ -51,5 +53,9 @@ func newCluster() *cobra.Command {
 			return nil
 		},
 	}
+
+	flags := cmd.Flags()
+	cluster = flags.StringSliceP("cluster", "c", defaultCluster, "addresses of existing cluster nodes")
+
 	return cmd
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -123,7 +123,7 @@ func WithAttemptTimeout(timeout time.Duration) Option {
 
 // WithRetryLimit sets the timeout for each individual connection attempt .
 //
-// If not used, the default is 5 seconds.
+// If not used, the default is 0 (unlimited retries)
 func WithRetryLimit(limit uint) Option {
 	return func(options *options) {
 		options.RetryLimit = limit

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -121,7 +121,7 @@ func WithAttemptTimeout(timeout time.Duration) Option {
 	}
 }
 
-// WithRetryLimit sets the timeout for each individual connection attempt .
+// WithRetryLimit sets the maximum number of connection retries.
 //
 // If not used, the default is 0 (unlimited retries)
 func WithRetryLimit(limit uint) Option {
@@ -166,7 +166,7 @@ func New(store client.NodeStore, options ...Option) (*Driver, error) {
 
 	driver.clientConfig.Dial = o.Dial
 	driver.clientConfig.AttemptTimeout = o.AttemptTimeout
-	driver.clientConfig.RetryStrategies = driverConnectionRetryStrategy(
+	driver.clientConfig.RetryStrategies = driverConnectionRetryStrategies(
 		o.ConnectionBackoffFactor,
 		o.ConnectionBackoffCap,
 		o.RetryLimit,
@@ -204,7 +204,7 @@ func defaultOptions() *options {
 
 // Return a retry strategy with jittered exponential backoff, capped at the
 // given amount of time.
-func driverConnectionRetryStrategy(factor, cap time.Duration, limit uint) []strategy.Strategy {
+func driverConnectionRetryStrategies(factor, cap time.Duration, limit uint) []strategy.Strategy {
 	backoff := backoff.BinaryExponential(factor)
 
 	strategies := []strategy.Strategy{

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -112,6 +112,24 @@ func WithConnectionBackoffCap(cap time.Duration) Option {
 	}
 }
 
+// WithAttemptTimeout sets the timeout for each individual connection attempt .
+//
+// If not used, the default is 5 seconds.
+func WithAttemptTimeout(timeout time.Duration) Option {
+	return func(options *options) {
+		options.AttemptTimeout = timeout
+	}
+}
+
+// WithRetryLimit sets the timeout for each individual connection attempt .
+//
+// If not used, the default is 5 seconds.
+func WithRetryLimit(limit uint) Option {
+	return func(options *options) {
+		options.RetryLimit = limit
+	}
+}
+
 // WithContext sets a global cancellation context.
 func WithContext(context context.Context) Option {
 	return func(options *options) {
@@ -147,13 +165,12 @@ func New(store client.NodeStore, options ...Option) (*Driver, error) {
 	}
 
 	driver.clientConfig.Dial = o.Dial
-	driver.clientConfig.AttemptTimeout = 5 * time.Second
-	driver.clientConfig.RetryStrategies = []strategy.Strategy{
-		driverConnectionRetryStrategy(
-			o.ConnectionBackoffFactor,
-			o.ConnectionBackoffCap,
-		),
-	}
+	driver.clientConfig.AttemptTimeout = o.AttemptTimeout
+	driver.clientConfig.RetryStrategies = driverConnectionRetryStrategy(
+		o.ConnectionBackoffFactor,
+		o.ConnectionBackoffCap,
+		o.RetryLimit,
+	)
 
 	return driver, nil
 }
@@ -162,10 +179,12 @@ func New(store client.NodeStore, options ...Option) (*Driver, error) {
 type options struct {
 	Log                     client.LogFunc
 	Dial                    protocol.DialFunc
+	AttemptTimeout          time.Duration
 	ConnectionTimeout       time.Duration
 	ContextTimeout          time.Duration
 	ConnectionBackoffFactor time.Duration
 	ConnectionBackoffCap    time.Duration
+	RetryLimit              uint
 	Context                 context.Context
 }
 
@@ -174,6 +193,7 @@ func defaultOptions() *options {
 	return &options{
 		Log:                     client.DefaultLogFunc,
 		Dial:                    client.DefaultDialFunc,
+		AttemptTimeout:          5 * time.Second,
 		ConnectionTimeout:       15 * time.Second,
 		ContextTimeout:          2 * time.Second,
 		ConnectionBackoffFactor: 50 * time.Millisecond,
@@ -184,20 +204,26 @@ func defaultOptions() *options {
 
 // Return a retry strategy with jittered exponential backoff, capped at the
 // given amount of time.
-func driverConnectionRetryStrategy(factor, cap time.Duration) strategy.Strategy {
+func driverConnectionRetryStrategy(factor, cap time.Duration, limit uint) []strategy.Strategy {
 	backoff := backoff.BinaryExponential(factor)
 
-	return func(attempt uint) bool {
-		if attempt > 0 {
-			duration := backoff(attempt)
-			if duration > cap {
-				duration = cap
+	strategies := []strategy.Strategy{
+		func(attempt uint) bool {
+			if attempt > 0 {
+				duration := backoff(attempt)
+				if duration > cap {
+					duration = cap
+				}
+				time.Sleep(duration)
 			}
-			time.Sleep(duration)
-		}
 
-		return true
+			return true
+		},
 	}
+	if limit > 0 {
+		strategies = append(strategies, strategy.Limit(limit))
+	}
+	return strategies
 }
 
 // Open establishes a new connection to a SQLite database on the dqlite server.

--- a/driver/integration_test.go
+++ b/driver/integration_test.go
@@ -248,7 +248,20 @@ func newDB(t *testing.T, n int) (*sql.DB, []*nodeHelper, func()) {
 	require.NoError(t, store.Set(context.Background(), infos))
 
 	log := logging.Test(t)
-	driver, err := driver.New(store, driver.WithLogFunc(log))
+
+	// all driver options below (except logging) represent the default settings,
+	// and are included for code coverage
+	driver, err := driver.New(
+		store,
+		driver.WithLogFunc(log),
+		driver.WithContext(context.Background()),
+		driver.WithConnectionTimeout(15*time.Second),
+		driver.WithContextTimeout(2*time.Second),
+		driver.WithConnectionBackoffFactor(50*time.Millisecond),
+		driver.WithConnectionBackoffCap(1*time.Second),
+		driver.WithAttemptTimeout(5*time.Second),
+		driver.WithRetryLimit(0),
+	)
 	require.NoError(t, err)
 
 	driverName := fmt.Sprintf("dqlite-integration-test-%d", driversCount)

--- a/driver/integration_test.go
+++ b/driver/integration_test.go
@@ -226,6 +226,9 @@ func TestIntegration_HighAvailability(t *testing.T) {
 	helpers[1].Start()
 	helpers[2].Start()
 
+	// Give the cluster a chance to establish a quorom
+	time.Sleep(2 * time.Second)
+
 	_, err = db.Exec("INSERT INTO test(n) VALUES(1)")
 	require.NoError(t, err)
 }

--- a/driver/integration_test.go
+++ b/driver/integration_test.go
@@ -233,6 +233,25 @@ func TestIntegration_HighAvailability(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestOptions(t *testing.T) {
+	// make sure applying all options doesn't break anything
+	store, err := client.DefaultNodeStore(":memory:")
+	require.NoError(t, err)
+	log := logging.Test(t)
+	_, err = driver.New(
+		store,
+		driver.WithLogFunc(log),
+		driver.WithContext(context.Background()),
+		driver.WithConnectionTimeout(15*time.Second),
+		driver.WithContextTimeout(2*time.Second),
+		driver.WithConnectionBackoffFactor(50*time.Millisecond),
+		driver.WithConnectionBackoffCap(1*time.Second),
+		driver.WithAttemptTimeout(5*time.Second),
+		driver.WithRetryLimit(0),
+	)
+	require.NoError(t, err)
+}
+
 func newDB(t *testing.T, n int) (*sql.DB, []*nodeHelper, func()) {
 	infos := make([]client.NodeInfo, n)
 	for i := range infos {
@@ -249,19 +268,7 @@ func newDB(t *testing.T, n int) (*sql.DB, []*nodeHelper, func()) {
 
 	log := logging.Test(t)
 
-	// all driver options below (except logging) represent the default settings,
-	// and are included for code coverage
-	driver, err := driver.New(
-		store,
-		driver.WithLogFunc(log),
-		driver.WithContext(context.Background()),
-		driver.WithConnectionTimeout(15*time.Second),
-		driver.WithContextTimeout(2*time.Second),
-		driver.WithConnectionBackoffFactor(50*time.Millisecond),
-		driver.WithConnectionBackoffCap(1*time.Second),
-		driver.WithAttemptTimeout(5*time.Second),
-		driver.WithRetryLimit(0),
-	)
+	driver, err := driver.New(store, driver.WithLogFunc(log))
 	require.NoError(t, err)
 
 	driverName := fmt.Sprintf("dqlite-integration-test-%d", driversCount)


### PR DESCRIPTION
After fixing my other open PR I encountered erratic test results on my local instance, and there was a TODO on making timing configurable so I've added that functionality.

A couple of pauses were inserted in the tests because the given timeouts were not quite enough. Local testing now appears to pass consistently.