### PR TITLE
add logger creation function

### DIFF
--- a/client/log.go
+++ b/client/log.go
@@ -50,7 +50,7 @@ func NewLogFunc(level LogLevel, prefix string, w io.Writer) LogFunc {
 		if l >= level {
 			// prepend the log level to the message
 			args = append([]interface{}{l.String()}, args...)
-			format = "[%s] " + format
+			format = prefix + "[%s] " + format
 			fmt.Fprintf(w, format, args...)
 		}
 	}

--- a/client/log.go
+++ b/client/log.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/canonical/go-dqlite/internal/logging"
 )
@@ -27,8 +28,26 @@ const (
 func DefaultLogFunc(l LogLevel, format string, a ...interface{}) {
 }
 
+// NewLogLevel returns the named log level
+func NewLogLevel(level string) (LogLevel, error) {
+	switch strings.ToLower(level) {
+	case "debug":
+		return LogDebug, nil
+	case "info":
+		return LogInfo, nil
+	case "warn":
+		return LogWarn, nil
+	case "error":
+		return LogError, nil
+	}
+	var meh LogLevel
+	return meh, fmt.Errorf("invalid log level: %q", level)
+}
+
+// LogWriter writes to the default go log
 type logWriter struct{}
 
+// Write satisfies io.Write interface
 func (l *logWriter) Write(in []byte) (int, error) {
 	log.Println(string(in))
 	return len(in), nil

--- a/client/log_test.go
+++ b/client/log_test.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"log"
+	"testing"
+)
+
+type writeCheck bool
+
+func (w *writeCheck) Write(in []byte) (int, error) {
+	*w = true
+	return len(in), nil
+}
+
+func TestNewLogFunc(t *testing.T) {
+	// first with nil to exercise the stdout assignment
+	logger := NewLogFunc(LogError, "", nil)
+
+	// now verify levels are respected
+	w := new(writeCheck)
+	logger = NewLogFunc(LogError, "", w)
+	logger(LogDebug, "hello")
+	if *w {
+		t.Fatal("log level ignored")
+	}
+	logger(LogError, "hello")
+	if !*w {
+		t.Fatal("log level did not print")
+	}
+}
+
+func TestLoggingWriter(t *testing.T) {
+	// now verify levels are respected
+	w := new(writeCheck)
+	log.SetOutput(w)
+	logger := NewLogFunc(LogError, "", NewLoggingWriter())
+	logger(LogDebug, "hello")
+	if *w {
+		t.Fatal("log level ignored")
+	}
+	logger(LogError, "hello")
+	if !*w {
+		t.Fatal("log level did not print")
+	}
+}

--- a/client/log_test.go
+++ b/client/log_test.go
@@ -3,6 +3,8 @@ package client
 import (
 	"log"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type writeCheck bool
@@ -42,4 +44,25 @@ func TestLoggingWriter(t *testing.T) {
 	if !*w {
 		t.Fatal("log level did not print")
 	}
+}
+
+func TestNewLogLevel(t *testing.T) {
+	l, err := NewLogLevel("debug")
+	assert.NoError(t, err)
+	assert.Equal(t, l, LogDebug)
+
+	l, err = NewLogLevel("info")
+	assert.NoError(t, err)
+	assert.Equal(t, l, LogInfo)
+
+	l, err = NewLogLevel("warn")
+	assert.NoError(t, err)
+	assert.Equal(t, l, LogWarn)
+
+	l, err = NewLogLevel("error")
+	assert.NoError(t, err)
+	assert.Equal(t, l, LogError)
+
+	l, err = NewLogLevel("invalid")
+	assert.Error(t, err)
 }

--- a/cmd/dqlite-demo/cluster.go
+++ b/cmd/dqlite-demo/cluster.go
@@ -20,12 +20,14 @@ var (
 
 // Return a cluster nodes command.
 func newCluster() *cobra.Command {
+	var cluster *[]string
+
 	cmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "display cluster nodes.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := getLeader(defaultCluster)
+			client, err := getLeader(*cluster)
 			if err != nil {
 				return errors.Wrap(err, "can't connect to cluster leader")
 			}
@@ -51,5 +53,9 @@ func newCluster() *cobra.Command {
 			return nil
 		},
 	}
+
+	flags := cmd.Flags()
+	cluster = flags.StringSliceP("cluster", "c", defaultCluster, "addresses of existing cluster nodes")
+
 	return cmd
 }


### PR DESCRIPTION
A new function to create a new customizable LogFunc, as well as an associated writer that uses the default go logger.