### PR TITLE
WIP: Add a load test

### DIFF
--- a/cmd/loadtest/hammer.go
+++ b/cmd/loadtest/hammer.go
@@ -44,7 +44,7 @@ func getDB(ctx context.Context, dbName string, cluster []string, logger LogFunc)
 	logOpt := driver.WithLogFunc(logger)
 	dbDriver, err := driver.New(store, logOpt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create dqlite driver: %w", err)
+		return nil, err
 	}
 	sql.Register("dqlite", dbDriver)
 

--- a/cmd/loadtest/hammer.go
+++ b/cmd/loadtest/hammer.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/canonical/go-dqlite/client"
+	"github.com/canonical/go-dqlite/driver"
+)
+
+// match log formatting with Lmicroseconds set
+const timeLayout = "2006/01/02 03:04:05.000000PM -0700"
+
+func ts() string {
+	return time.Now().Local().Format(timeLayout)
+}
+
+type tsWriter struct{}
+
+func (t tsWriter) Write(in []byte) (int, error) {
+	fmt.Println(ts(), string(in))
+	return len(in), nil
+}
+
+func getStore(ctx context.Context, cluster []string) client.NodeStore {
+	store := client.NewInmemNodeStore()
+	infos := make([]client.NodeInfo, len(cluster))
+	for i, address := range cluster {
+		infos[i].ID = uint64(i + 1)
+		infos[i].Address = address
+	}
+	store.Set(ctx, infos)
+	return store
+}
+
+func getDB(ctx context.Context, dbName string, cluster []string, logger LogFunc) (*sql.DB, error) {
+	store := getStore(ctx, cluster)
+	if logger != nil {
+		logger = client.DefaultLogFunc
+	}
+	logOpt := driver.WithLogFunc(logger)
+	dbDriver, err := driver.New(store, logOpt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dqlite driver: %w", err)
+	}
+	sql.Register("dqlite", dbDriver)
+
+	db, err := sql.Open("dqlite", dbName)
+	if err == nil {
+		db.SetMaxOpenConns(1) // dqlite is single-threaded
+	}
+	return db, err
+}
+
+func prep(db *sql.DB) error {
+	const drop = "drop table if exists simple"
+	const create = "create table simple (id integer primary key, other integer, ts text)"
+	if _, err := db.Exec(drop); err != nil {
+		return err
+	}
+	_, err := db.Exec(create)
+	return err
+}
+
+func hammer(count int, abort bool, logger LogFunc, dbName string, cluster []string) {
+	db, err := getDB(context.Background(), dbName, cluster, logger)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println("connected")
+	defer db.Close()
+	if err := prep(db); err != nil {
+		log.Fatalln(err)
+	}
+	hammerTime(db, count, abort)
+}
+
+func hammerTime(db *sql.DB, count int, abort bool) {
+	var now string
+	var fails, good, last int
+
+	started := time.Now().Local()
+	fmt.Printf("%s starting\n", started.Format(timeLayout))
+	for i := 0; ; i++ {
+		if count > 0 && i >= count {
+			break
+		}
+		const insert = "insert into simple (other, ts) values(%d,%q)"
+		inserted := fmt.Sprintf(insert, last+1, ts())
+		resp, err := db.Exec(inserted)
+		if err != nil {
+			fails++
+			// first err (in a contiguous series?)
+			if fails == 1 {
+				// if so mark the starting point of the failure
+				now = ts()
+
+			}
+			fmt.Printf("%s fails: %3d (%d/%d):%T %-30s\r", now, fails, i, count, err, err.Error())
+			continue
+		}
+		if id, err := resp.LastInsertId(); err != nil {
+			fmt.Printf("%s failed to get insert id: %+v\n", now, err)
+			continue
+		} else {
+			last = int(id)
+		}
+		if fails > 0 {
+			fmt.Printf("\n%s fixed: (%d/%d)\n", ts(), good, count)
+			fails = 0
+		}
+		// As we're keeping track of every successful insert,
+		// the generated id should always be in sync with
+		// the known count of inserted records
+		good++
+		if last != good {
+			// If there's a mismatch between expected and returned,
+			// then we've encountered a double write, and this can
+			// be shown by selecting records where other = good.
+			fmt.Printf("%s offby: (%d/%d)\n", ts(), last, good)
+			good = last // reset to avoid repeating same error
+			if abort {
+				break
+			}
+		}
+		// visual reminder test is running
+		if (good % 1000) == 0 {
+			now = time.Now().Format(timeLayout)
+			fmt.Printf("%s  good: (%d/%d)\n", ts(), good, count)
+		}
+	}
+	delta := time.Now().Sub(started)
+	total := good + fails
+	if total > 0 {
+		per := delta / time.Duration(total)
+		fmt.Printf("\ncompleted %d/%d (%s/insert)\n", good, total, per)
+	}
+}

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -1,0 +1,78 @@
+package main
+
+// This command will execute a series of inserts into a
+// fresh database table ('simple'), comprising:
+//
+// id:    integer primary key (auto-incrementing)
+// other: integer that should mirror the id field
+// ts:    text, a text timestamp with microsecond resolution
+//
+// It is intendend to put go-dqlite under maximum load so that
+// durability and consistency can be probed at the edges of
+// its performance.
+
+import (
+	"flag"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/canonical/go-dqlite/client"
+)
+
+const defaultCluster = "127.0.0.1:9181,127.0.0.1:9182,127.0.0.1:9183"
+
+var (
+	cluster  string
+	dbName   string
+	logLevel string
+	count    int
+	fail     bool
+)
+
+func init() {
+	flag.StringVar(&cluster, "cluster", defaultCluster, "list of nodes in the cluster")
+	flag.StringVar(&dbName, "database", "demo.db", "name of database to use")
+	flag.StringVar(&logLevel, "level", "error", "logging level: {debug|info|warn|error}")
+	flag.IntVar(&count, "count", 10000, "how many times to repeat (0 is infinite)")
+	flag.BoolVar(&fail, "fail", false, "exit test if data is corrupted)")
+}
+
+// NewLogFunc returns a LogFunc.
+func NewLogFunc(level LogLevel, prefix string, w io.Writer) LogFunc {
+	if w == nil {
+		w = os.Stdout
+	}
+	logger := log.New(w, prefix, log.LstdFlags|log.Lmicroseconds)
+	return func(l LogLevel, format string, args ...interface{}) {
+		if l >= level {
+			// prepend the log level to the message
+			args = append([]interface{}{l.String()}, args...)
+			format = "[%s] " + format
+			logger.Printf(format, args...)
+		}
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	var level client.LogLevel
+	switch strings.ToLower(logLevel) {
+	case "error":
+		level = client.LogDebug
+	case "warn":
+		level = client.LogWarn
+	case "info":
+		level = client.LogInfo
+	case "debug":
+		level = client.LogDebug
+	default:
+		flag.Usage()
+		log.Fatalln("not a valid log level:", logLevel)
+	}
+
+	logger := NewLogFunc(level, "hammer:", &tsWriter{})
+	hammer(count, fail, logger, dbName, strings.Split(cluster, ","))
+}

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -39,6 +39,12 @@ func init() {
 	flag.BoolVar(&fail, "fail", false, "exit test if data is corrupted)")
 }
 
+// LogFunc is a go-dqlite logging function
+type LogFunc = client.LogFunc
+
+// LogLevel is a go-dqlite logging level
+type LogLevel = client.LogLevel
+
 // NewLogFunc returns a LogFunc.
 func NewLogFunc(level LogLevel, prefix string, w io.Writer) LogFunc {
 	if w == nil {

--- a/cmd/loadtest/transfer.go
+++ b/cmd/loadtest/transfer.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/canonical/go-dqlite/client"
+)
+
+func getLeader(cluster []string) (*client.Client, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	store := getStore(ctx, cluster)
+	return client.FindLeader(ctx, store)
+}
+
+func transfer(id uint64, cluster []string) error {
+	client, err := getLeader(cluster)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	return client.Transfer(context.Background(), id)
+}
+
+func rotateLeadership(cluster []string) {
+	client, err := getLeader(cluster)
+	if err != nil {
+		log.Fatalln("error getting client:", err)
+	}
+	nodes, err := client.Cluster(context.Background())
+	if err != nil {
+		log.Fatalln("can't get node info:", err)
+	}
+
+	skip := true // node 1 will be leader, don't start with it
+	for {
+		for _, node := range nodes {
+			if skip {
+				skip = false
+				continue
+			}
+			if err = transfer(node.ID, cluster); err != nil {
+				log.Printf("error transferring leadership to node: %d -- %v\n", node.ID, err)
+			} else {
+				log.Println("transferred leadership to node:", node.ID)
+			}
+			time.Sleep(time.Second)
+		}
+	}
+
+}


### PR DESCRIPTION
This adds cmd/loadtest which will create a table and insert records into it without pause.

The table in question: `create table simple (id integer primary key, other integer, ts text)`

The canary in this coal mine is that it tracks the successful inserts and uses the returned `Result. LastInsertId` to keep track of valid the last successful insert and includes that as `other` in the record insertion.

When the number of known successful writes fails to match the last id the command will optionally stop. Examination of the table at that point will show 2 records inserted with the same value for `other`. This can be demonstrated by simultaneously running a script that transfers leadership from node to node (which I guess I should probably include?)

The errors are rare and random but do occur in time.