### PR TITLE
add context to getLeader function

### DIFF
--- a/cmd/dqlite-demo/add.go
+++ b/cmd/dqlite-demo/add.go
@@ -36,14 +36,14 @@ func newAdd() *cobra.Command {
 				Address: address,
 			}
 
-			client, err := getLeader(*cluster)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			client, err := getLeader(ctx, *cluster)
 			if err != nil {
 				return errors.Wrap(err, "can't connect to cluster leader")
 			}
 			defer client.Close()
-
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-			defer cancel()
 
 			if err := client.Add(ctx, info); err != nil {
 				return errors.Wrap(err, "can't add node")

--- a/cmd/dqlite-demo/client.go
+++ b/cmd/dqlite-demo/client.go
@@ -2,28 +2,19 @@ package main
 
 import (
 	"context"
-	"time"
 
 	"github.com/canonical/go-dqlite/client"
 )
 
-func getLeader(cluster []string) (*client.Client, error) {
-	store := getStore(cluster)
+func getLeader(ctx context.Context, cluster []string) (*client.Client, error) {
+	return client.FindLeader(ctx, getStore(cluster))
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	return client.FindLeader(ctx, store)
 }
 
 func getStore(cluster []string) client.NodeStore {
 	store := client.NewInmemNodeStore()
 	if len(cluster) == 0 {
-		cluster = []string{
-			"127.0.0.1:9181",
-			"127.0.0.1:9182",
-			"127.0.0.1:9183",
-		}
+		cluster = defaultCluster
 	}
 	infos := make([]client.NodeInfo, 3)
 	for i, address := range cluster {

--- a/cmd/dqlite-demo/cluster.go
+++ b/cmd/dqlite-demo/cluster.go
@@ -27,14 +27,14 @@ func newCluster() *cobra.Command {
 		Short: "display cluster nodes.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := getLeader(*cluster)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			client, err := getLeader(ctx, *cluster)
 			if err != nil {
 				return errors.Wrap(err, "can't connect to cluster leader")
 			}
 			defer client.Close()
-
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-			defer cancel()
 
 			var leader *dqclient.NodeInfo
 			var nodes []dqclient.NodeInfo


### PR DESCRIPTION
Exposing context to allow timeouts to be configurable from command line functions.