### PR TITLE
Cleanup timeout logic

### DIFF
--- a/client/leader.go
+++ b/client/leader.go
@@ -2,10 +2,7 @@ package client
 
 import (
 	"context"
-	"time"
 
-	"github.com/Rican7/retry/backoff"
-	"github.com/Rican7/retry/strategy"
 	"github.com/canonical/go-dqlite/internal/protocol"
 )
 
@@ -18,10 +15,7 @@ func FindLeader(ctx context.Context, store NodeStore, options ...Option) (*Clien
 	}
 
 	config := protocol.Config{
-		Dial:           o.DialFunc,
-		AttemptTimeout: time.Second,
-		RetryStrategies: []strategy.Strategy{
-			strategy.Backoff(backoff.BinaryExponential(time.Millisecond))},
+		Dial: o.DialFunc,
 	}
 	connector := protocol.NewConnector(0, store, config, o.LogFunc)
 	protocol, err := connector.Connect(ctx)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -95,7 +95,7 @@ func WithConnectionTimeout(timeout time.Duration) Option {
 // WithConnectionBackoffFactor sets the exponential backoff factor for retrying
 // failed connection attempts.
 //
-// If not used, the default is 50 milliseconds.
+// If not used, the default is 100 milliseconds.
 func WithConnectionBackoffFactor(factor time.Duration) Option {
 	return func(options *options) {
 		options.ConnectionBackoffFactor = factor
@@ -114,7 +114,7 @@ func WithConnectionBackoffCap(cap time.Duration) Option {
 
 // WithAttemptTimeout sets the timeout for each individual connection attempt .
 //
-// If not used, the default is 5 seconds.
+// If not used, the default is 60 seconds.
 func WithAttemptTimeout(timeout time.Duration) Option {
 	return func(options *options) {
 		options.AttemptTimeout = timeout
@@ -166,11 +166,9 @@ func New(store client.NodeStore, options ...Option) (*Driver, error) {
 
 	driver.clientConfig.Dial = o.Dial
 	driver.clientConfig.AttemptTimeout = o.AttemptTimeout
-	driver.clientConfig.RetryStrategies = driverConnectionRetryStrategies(
-		o.ConnectionBackoffFactor,
-		o.ConnectionBackoffCap,
-		o.RetryLimit,
-	)
+	driver.clientConfig.BackoffFactor = o.ConnectionBackoffFactor
+	driver.clientConfig.BackoffCap = o.ConnectionBackoffCap
+	driver.clientConfig.RetryLimit = o.RetryLimit
 
 	return driver, nil
 }
@@ -191,14 +189,11 @@ type options struct {
 // Create a options object with sane defaults.
 func defaultOptions() *options {
 	return &options{
-		Log:                     client.DefaultLogFunc,
-		Dial:                    client.DefaultDialFunc,
-		AttemptTimeout:          5 * time.Second,
-		ConnectionTimeout:       15 * time.Second,
-		ContextTimeout:          2 * time.Second,
-		ConnectionBackoffFactor: 50 * time.Millisecond,
-		ConnectionBackoffCap:    time.Second,
-		Context:                 context.Background(),
+		Log:               client.DefaultLogFunc,
+		Dial:              client.DefaultDialFunc,
+		ConnectionTimeout: 15 * time.Second,
+		ContextTimeout:    2 * time.Second,
+		Context:           context.Background(),
 	}
 }
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -134,6 +134,9 @@ func WithRetryLimit(limit uint) Option {
 }
 
 // WithContext sets a global cancellation context.
+//
+// DEPRECATED: This API is no a no-op. Users should explicitly pass a context
+// if they wish to cancel their requests.
 func WithContext(context context.Context) Option {
 	return func(options *options) {
 		options.Context = context
@@ -143,7 +146,8 @@ func WithContext(context context.Context) Option {
 // WithContextTimeout sets the default client context timeout when no context
 // deadline is provided.
 //
-// If not used, the default is 5 seconds.
+// DEPRECATED: This API is no a no-op. Users should explicitly pass a context
+// if they wish to cancel their requests.
 func WithContextTimeout(timeout time.Duration) Option {
 	return func(options *options) {
 		options.ContextTimeout = timeout
@@ -192,10 +196,8 @@ type options struct {
 // Create a options object with sane defaults.
 func defaultOptions() *options {
 	return &options{
-		Log:            client.DefaultLogFunc,
-		Dial:           client.DefaultDialFunc,
-		ContextTimeout: 2 * time.Second,
-		Context:        context.Background(),
+		Log:  client.DefaultLogFunc,
+		Dial: client.DefaultDialFunc,
 	}
 }
 
@@ -255,7 +257,6 @@ func (c *Connector) Connect(ctx context.Context) (driver.Conn, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create dqlite connection")
 	}
-	conn.protocol.SetContextTimeout(c.driver.contextTimeout)
 
 	conn.request.Init(4096)
 	conn.response.Init(4096)
@@ -314,9 +315,10 @@ func (d *Driver) Open(uri string) (driver.Conn, error) {
 
 // SetContextTimeout sets the default client timeout when no context deadline
 // is provided.
-func (d *Driver) SetContextTimeout(timeout time.Duration) {
-	d.contextTimeout = timeout
-}
+//
+// DEPRECATED: This API is no a no-op. Users should explicitly pass a context
+// if they wish to cancel their requests.
+func (d *Driver) SetContextTimeout(timeout time.Duration) {}
 
 // ErrNoAvailableLeader is returned as root cause of Open() if there's no
 // leader available in the cluster.

--- a/driver/integration_test.go
+++ b/driver/integration_test.go
@@ -221,7 +221,9 @@ func TestIntegration_PingOnlyWorksOnceLeaderElected(t *testing.T) {
 	helpers[0].Close()
 
 	// Ping returns an error, since the cluster is not available.
-	assert.Error(t, db.Ping())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	assert.Error(t, db.PingContext(ctx))
 
 	helpers[0].Create()
 	helpers[0].Start()

--- a/internal/protocol/config.go
+++ b/internal/protocol/config.go
@@ -7,6 +7,7 @@ import (
 // Config holds various configuration parameters for a dqlite client.
 type Config struct {
 	Dial           DialFunc      // Network dialer.
+	DialTimeout    time.Duration // Timeout for establishing a network connection .
 	AttemptTimeout time.Duration // Timeout for each individual attempt to probe a server's leadership.
 	BackoffFactor  time.Duration // Exponential backoff factor for retries.
 	BackoffCap     time.Duration // Maximum connection retry backoff value,

--- a/internal/protocol/config.go
+++ b/internal/protocol/config.go
@@ -2,13 +2,13 @@ package protocol
 
 import (
 	"time"
-
-	"github.com/Rican7/retry/strategy"
 )
 
 // Config holds various configuration parameters for a dqlite client.
 type Config struct {
-	Dial            DialFunc            // Network dialer.
-	AttemptTimeout  time.Duration       // Timeout for each individual Dial attempt.
-	RetryStrategies []strategy.Strategy // Strategies used for retrying to connect to a leader.
+	Dial           DialFunc      // Network dialer.
+	AttemptTimeout time.Duration // Timeout for each individual attempt to probe a server's leadership.
+	BackoffFactor  time.Duration // Exponential backoff factor for retries.
+	BackoffCap     time.Duration // Maximum connection retry backoff value,
+	RetryLimit     uint          // Maximum number of retries, or 0 for unlimited.
 }

--- a/internal/protocol/connector.go
+++ b/internal/protocol/connector.go
@@ -181,7 +181,7 @@ func Handshake(ctx context.Context, conn net.Conn, version uint64) (*Protocol, e
 		return nil, errors.Wrap(io.ErrShortWrite, "failed to send handshake")
 	}
 
-	return NewProtocol(version, conn), nil
+	return newProtocol(version, conn), nil
 }
 
 // Connect to the given dqlite server and check if it's the leader.

--- a/internal/protocol/connector.go
+++ b/internal/protocol/connector.go
@@ -61,7 +61,6 @@ func (c *Connector) Connect(ctx context.Context) (*Protocol, error) {
 		var err error
 		protocol, err = c.connectAttemptAll(ctx, log)
 		if err != nil {
-			log(logging.Error, "connection failed err=%v", err)
 			return err
 		}
 
@@ -69,9 +68,9 @@ func (c *Connector) Connect(ctx context.Context) (*Protocol, error) {
 	}, c.config.RetryStrategies...)
 
 	if err != nil {
-		// The retry strategy should never give up until success or
-		// context expiration.
-		panic("connect retry aborted unexpectedly")
+		// We exhausted the number of retries allowed by the configured
+		// strategy.
+		return nil, ErrNoAvailableLeader
 	}
 
 	if ctx.Err() != nil {

--- a/internal/protocol/connector.go
+++ b/internal/protocol/connector.go
@@ -283,7 +283,8 @@ func makeRetryStrategies(factor, cap time.Duration, limit uint) []strategy.Strat
 		func(attempt uint) bool {
 			if attempt > 0 {
 				duration := backoff(attempt)
-				if duration > cap {
+				// Duration might be negative in case of integer overflow.
+				if duration > cap || duration <= 0 {
 					duration = cap
 				}
 				time.Sleep(duration)

--- a/internal/protocol/connector.go
+++ b/internal/protocol/connector.go
@@ -112,7 +112,7 @@ func (c *Connector) connectAttemptAll(ctx context.Context, log logging.Func) (*P
 	// Make an attempt for each address until we find the leader.
 	for _, server := range servers {
 		log := func(l logging.Level, format string, a ...interface{}) {
-			format += fmt.Sprintf(" address=%s id=%d", server.Address, server.ID)
+			format += fmt.Sprintf(" address=%s", server.Address)
 			log(l, format, a...)
 		}
 

--- a/internal/protocol/connector.go
+++ b/internal/protocol/connector.go
@@ -176,6 +176,12 @@ func Handshake(ctx context.Context, conn net.Conn, version uint64) (*Protocol, e
 	protocol := make([]byte, 8)
 	binary.LittleEndian.PutUint64(protocol, version)
 
+	// Honor the ctx deadline, if present.
+	if deadline, ok := ctx.Deadline(); ok {
+		conn.SetDeadline(deadline)
+		defer conn.SetDeadline(time.Time{})
+	}
+
 	// Perform the protocol handshake.
 	n, err := conn.Write(protocol)
 	if err != nil {

--- a/internal/protocol/connector.go
+++ b/internal/protocol/connector.go
@@ -127,7 +127,7 @@ func (c *Connector) connectAttemptAll(ctx context.Context, log logging.Func) (*P
 		}
 		if err != nil {
 			// This server is unavailable, try with the next target.
-			log(logging.Info, "server unavailable err=%v", err)
+			log(logging.Warn, "server unavailable err=%v", err)
 			continue
 		}
 		if protocol != nil {
@@ -138,7 +138,7 @@ func (c *Connector) connectAttemptAll(ctx context.Context, log logging.Func) (*P
 		if leader == "" {
 			// This server does not know who the current leader is,
 			// try with the next target.
-			log(logging.Info, "no known leader")
+			log(logging.Warn, "no known leader")
 			continue
 		}
 
@@ -154,13 +154,13 @@ func (c *Connector) connectAttemptAll(ctx context.Context, log logging.Func) (*P
 		if err != nil {
 			// The leader reported by the previous server is
 			// unavailable, try with the next target.
-			log(logging.Info, "reported leader unavailable err=%v", err)
+			log(logging.Warn, "reported leader unavailable err=%v", err)
 			continue
 		}
 		if protocol == nil {
 			// The leader reported by the target server does not consider itself
 			// the leader, try with the next target.
-			log(logging.Info, "reported leader server is not the leader")
+			log(logging.Warn, "reported leader server is not the leader")
 			continue
 		}
 		log(logging.Info, "connected")

--- a/internal/protocol/connector.go
+++ b/internal/protocol/connector.go
@@ -124,8 +124,11 @@ func (c *Connector) connectAttemptAll(ctx context.Context, log logging.Func) (*P
 		// If we get here, it means this server reported that another
 		// server is the leader, let's close the connection to this
 		// server and try with the suggested one.
-		//logger = logger.With(zap.String("leader", leader))
 		log(logging.Info, "connect to reported leader %s", leader)
+
+		ctx, cancel = context.WithTimeout(ctx, c.config.AttemptTimeout)
+		defer cancel()
+
 		protocol, leader, err = c.connectAttemptOne(ctx, leader, version)
 		if err != nil {
 			// The leader reported by the previous server is

--- a/internal/protocol/connector_test.go
+++ b/internal/protocol/connector_test.go
@@ -275,7 +275,7 @@ func newNode(t *testing.T, index int) (string, func()) {
 func newDir(t *testing.T) (string, func()) {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "dqlite-replication-test-")
+	dir, err := ioutil.TempDir("", "dqlite-connector-test-")
 	assert.NoError(t, err)
 
 	cleanup := func() {

--- a/internal/protocol/connector_test.go
+++ b/internal/protocol/connector_test.go
@@ -225,11 +225,15 @@ func newConnector(t *testing.T, store protocol.NodeStore) *protocol.Connector {
 		},
 	}
 
+	return newConnectorWithConfig(t, store, config)
+}
+
+func newConnectorWithConfig(t *testing.T, store protocol.NodeStore, config protocol.Config) *protocol.Connector {
+	t.Helper()
+
 	log := logging.Test(t)
 
-	connector := protocol.NewConnector(0, store, config, log)
-
-	return connector
+	return protocol.NewConnector(0, store, config, log)
 }
 
 // Create a new in-memory server store populated with the given addresses.

--- a/internal/protocol/connector_test.go
+++ b/internal/protocol/connector_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Rican7/retry/backoff"
-	"github.com/Rican7/retry/strategy"
 	"github.com/canonical/go-dqlite/internal/bindings"
 	"github.com/canonical/go-dqlite/internal/logging"
 	"github.com/canonical/go-dqlite/internal/protocol"
@@ -43,10 +41,7 @@ func TestConnector_LimitRetries(t *testing.T) {
 	config := protocol.Config{
 		Dial:           protocol.UnixDial,
 		AttemptTimeout: 100 * time.Millisecond,
-		RetryStrategies: []strategy.Strategy{
-			strategy.Limit(2),
-			strategy.Backoff(backoff.BinaryExponential(time.Millisecond)),
-		},
+		RetryLimit:     2,
 	}
 	connector := newConnectorWithConfig(t, store, config)
 
@@ -60,9 +55,7 @@ func TestConnector_ContextExpired(t *testing.T) {
 	config := protocol.Config{
 		Dial:           protocol.TCPDial,
 		AttemptTimeout: 50 * time.Millisecond,
-		RetryStrategies: []strategy.Strategy{
-			strategy.Backoff(backoff.BinaryExponential(time.Millisecond)),
-		},
+		BackoffFactor:  time.Millisecond,
 	}
 	connector := newConnectorWithConfig(t, store, config)
 
@@ -257,9 +250,7 @@ func newConnector(t *testing.T, store protocol.NodeStore) *protocol.Connector {
 	config := protocol.Config{
 		Dial:           protocol.UnixDial,
 		AttemptTimeout: 100 * time.Millisecond,
-		RetryStrategies: []strategy.Strategy{
-			strategy.Backoff(backoff.BinaryExponential(time.Millisecond)),
-		},
+		BackoffFactor:  time.Millisecond,
 	}
 
 	return newConnectorWithConfig(t, store, config)

--- a/internal/protocol/connector_test.go
+++ b/internal/protocol/connector_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/canonical/go-dqlite/internal/bindings"
 	"github.com/canonical/go-dqlite/internal/logging"
 	"github.com/canonical/go-dqlite/internal/protocol"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -298,11 +297,4 @@ func newListener(t *testing.T) net.Listener {
 	require.NoError(t, err)
 
 	return listener
-}
-
-func init() {
-	err := bindings.ConfigSingleThread()
-	if err != nil {
-		panic(errors.Wrap(err, "failed to initialize dqlite"))
-	}
 }

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -21,7 +21,7 @@ type Protocol struct {
 	netErr         error         // A network error occurred
 }
 
-func NewProtocol(version uint64, conn net.Conn) *Protocol {
+func newProtocol(version uint64, conn net.Conn) *Protocol {
 	protocol := &Protocol{
 		version:        version,
 		conn:           conn,

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -50,13 +50,11 @@ func (p *Protocol) Call(ctx context.Context, request, response *Message) (err er
 		return p.netErr
 	}
 
-	// Honor the ctx deadline, if present, or use a default.
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		deadline = time.Now().Add(p.contextTimeout)
+	// Honor the ctx deadline, if present.
+	if deadline, ok := ctx.Deadline(); ok {
+		p.conn.SetDeadline(deadline)
+		defer p.conn.SetDeadline(time.Time{})
 	}
-
-	p.conn.SetDeadline(deadline)
 
 	if err = p.send(request); err != nil {
 		err = errors.Wrap(err, "failed to send request")
@@ -91,12 +89,11 @@ func (p *Protocol) Interrupt(ctx context.Context, request *Message, response *Me
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// Honor the ctx deadline, if present, or use a default.
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		deadline = time.Now().Add(2 * time.Second)
+	// Honor the ctx deadline, if present.
+	if deadline, ok := ctx.Deadline(); ok {
+		p.conn.SetDeadline(deadline)
+		defer p.conn.SetDeadline(time.Time{})
 	}
-	p.conn.SetDeadline(deadline)
 
 	defer request.Reset()
 

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -13,29 +13,21 @@ import (
 
 // Protocol sends and receive the dqlite message on the wire.
 type Protocol struct {
-	version        uint64        // Protocol version
-	conn           net.Conn      // Underlying network connection.
-	contextTimeout time.Duration // Default context timeout.
-	closeCh        chan struct{} // Stops the heartbeat when the connection gets closed
-	mu             sync.Mutex    // Serialize requests
-	netErr         error         // A network error occurred
+	version uint64        // Protocol version
+	conn    net.Conn      // Underlying network connection.
+	closeCh chan struct{} // Stops the heartbeat when the connection gets closed
+	mu      sync.Mutex    // Serialize requests
+	netErr  error         // A network error occurred
 }
 
 func newProtocol(version uint64, conn net.Conn) *Protocol {
 	protocol := &Protocol{
-		version:        version,
-		conn:           conn,
-		closeCh:        make(chan struct{}),
-		contextTimeout: 5 * time.Second,
+		version: version,
+		conn:    conn,
+		closeCh: make(chan struct{}),
 	}
 
 	return protocol
-}
-
-// SetContextTimeout sets the default context timeout when no deadline is
-// provided.
-func (p *Protocol) SetContextTimeout(timeout time.Duration) {
-	p.contextTimeout = timeout
 }
 
 // Call invokes a dqlite RPC, sending a request message and receiving a


### PR DESCRIPTION
This branch moves closer to remove hard-coded timeouts in the code base and have them instead controlled by the user with ```context.Context``` objects.

A few APIs have been deprecated to signal that users writing new code should favor context-aware APIs instead.