### PR TITLE
Use a single buffer for sending and receiving messages

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -60,16 +60,10 @@ func TestClient_Dump(t *testing.T) {
 	db, err := protocol.DecodeDb(&response)
 	require.NoError(t, err)
 
-	request.Reset()
-	response.Reset()
-
 	protocol.EncodeExecSQL(&request, uint64(db), "CREATE TABLE foo (n INT)", nil)
 
 	err = p.Call(ctx, &request, &response)
 	require.NoError(t, err)
-
-	request.Reset()
-	response.Reset()
 
 	files, err := client.Dump(ctx, "test.db")
 	require.NoError(t, err)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -24,8 +24,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Rican7/retry/backoff"
-	"github.com/Rican7/retry/strategy"
 	"github.com/pkg/errors"
 
 	"github.com/canonical/go-dqlite/client"
@@ -199,30 +197,6 @@ func defaultOptions() *options {
 		Log:  client.DefaultLogFunc,
 		Dial: client.DefaultDialFunc,
 	}
-}
-
-// Return a retry strategy with jittered exponential backoff, capped at the
-// given amount of time.
-func driverConnectionRetryStrategies(factor, cap time.Duration, limit uint) []strategy.Strategy {
-	backoff := backoff.BinaryExponential(factor)
-
-	strategies := []strategy.Strategy{
-		func(attempt uint) bool {
-			if attempt > 0 {
-				duration := backoff(attempt)
-				if duration > cap {
-					duration = cap
-				}
-				time.Sleep(duration)
-			}
-
-			return true
-		},
-	}
-	if limit > 0 {
-		strategies = append(strategies, strategy.Limit(limit))
-	}
-	return strategies
 }
 
 // A Connector represents a driver in a fixed configuration and can create any

--- a/internal/protocol/connector.go
+++ b/internal/protocol/connector.go
@@ -132,7 +132,7 @@ func (c *Connector) connectAttemptAll(ctx context.Context, log logging.Func) (*P
 		}
 		if protocol != nil {
 			// We found the leader
-			log(logging.Info, "connected")
+			log(logging.Debug, "connected")
 			return protocol, nil
 		}
 		if leader == "" {

--- a/internal/protocol/connector.go
+++ b/internal/protocol/connector.go
@@ -252,8 +252,8 @@ func (c *Connector) connectAttemptOne(ctx context.Context, address string, versi
 		return nil, "", nil
 	case address:
 		// This server is the leader, register ourselves and return.
-		request.Reset()
-		response.Reset()
+		request.reset()
+		response.reset()
 
 		EncodeClient(&request, c.id)
 

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -412,8 +412,7 @@ func (m *Message) getFiles() Files {
 
 func (m *Message) hasBeenConsumed() bool {
 	size := int(m.words * messageWordSize)
-	return (m.body1.Offset == size || m.body1.Offset == len(m.body1.Bytes)) &&
-		m.body1.Offset+m.body2.Offset == size
+	return m.body1.Offset == size
 }
 
 func (m *Message) lastByte() byte {

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -422,13 +422,10 @@ func (m *Message) lastByte() byte {
 
 func (m *Message) bufferForGet() *buffer {
 	size := int(m.words * messageWordSize)
-	if m.body1.Offset == size || m.body1.Offset == len(m.body1.Bytes) {
-		// The static body has been exahusted, use the dynamic one.
-		if m.body1.Offset+m.body2.Offset == size {
-			err := fmt.Errorf("short message: type=%d words=%d off=%d", m.mtype, m.words, m.body1.Offset)
-			panic(err)
-		}
-		return &m.body2
+	// The static body has been exahusted, use the dynamic one.
+	if m.body1.Offset == size {
+		err := fmt.Errorf("short message: type=%d words=%d off=%d", m.mtype, m.words, m.body1.Offset)
+		panic(err)
 	}
 
 	return &m.body1

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -417,10 +417,6 @@ func (m *Message) hasBeenConsumed() bool {
 
 func (m *Message) lastByte() byte {
 	size := int(m.words * messageWordSize)
-	if size > len(m.body1.Bytes) {
-		size = size - m.body1.Offset
-		return m.body2.Bytes[size-1]
-	}
 	return m.body1.Bytes[size-1]
 }
 

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -27,7 +27,6 @@ type Message struct {
 	extra  uint16
 	header []byte // Statically allocated header buffer
 	body1  buffer // Statically allocated body data, using bytes
-	body2  buffer // Dynamically allocated body data
 }
 
 // Init initializes the message using the given initial size for the data
@@ -52,8 +51,6 @@ func (m *Message) Reset() {
 		m.header[i] = 0
 	}
 	m.body1.Offset = 0
-	m.body2.Bytes = nil
-	m.body2.Offset = 0
 }
 
 // Append a byte slice to the message.

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -30,15 +30,15 @@ type Message struct {
 	body2  buffer // Dynamically allocated body data
 }
 
-// Init initializes the message using the given size of the statically
-// allocated buffer (i.e. a buffer which is re-used across requests or
-// responses encoded or decoded using this message object).
-func (m *Message) Init(staticSize int) {
-	if (staticSize % messageWordSize) != 0 {
-		panic("static size is not aligned to word boundary")
+// Init initializes the message using the given initial size for the data
+// buffer, which is re-used across requests or responses encoded or decoded
+// using this message object.
+func (m *Message) Init(initialBufferSize int) {
+	if (initialBufferSize % messageWordSize) != 0 {
+		panic("initial buffer size is not aligned to word boundary")
 	}
 	m.header = make([]byte, messageHeaderSize)
-	m.body1.Bytes = make([]byte, staticSize)
+	m.body1.Bytes = make([]byte, initialBufferSize)
 	m.Reset()
 }
 

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -246,21 +246,6 @@ func (m *Message) putHeader(mtype uint8) {
 
 	m.words = uint32(m.body1.Offset) / messageWordSize
 
-	if m.body2.Bytes == nil {
-		m.finalize()
-		return
-	}
-
-	if m.body2.Offset <= 0 {
-		panic("dynamic offset is not positive")
-	}
-
-	if (m.body2.Offset % messageWordSize) != 0 {
-		panic("dynamic body is not aligned")
-	}
-
-	m.words += uint32(m.body2.Offset) / messageWordSize
-
 	m.finalize()
 }
 

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -38,11 +38,11 @@ func (m *Message) Init(initialBufferSize int) {
 	}
 	m.header = make([]byte, messageHeaderSize)
 	m.body1.Bytes = make([]byte, initialBufferSize)
-	m.Reset()
+	m.reset()
 }
 
 // Reset the state of the message so it can be used to encode or decode again.
-func (m *Message) Reset() {
+func (m *Message) reset() {
 	m.words = 0
 	m.mtype = 0
 	m.flags = 0
@@ -575,7 +575,7 @@ func (r *Rows) Close() error {
 			err = fmt.Errorf("unexpected end of message")
 		}
 	}
-	r.message.Reset()
+	r.message.reset()
 	return err
 }
 
@@ -600,7 +600,7 @@ func (f *Files) Next() (string, []byte) {
 }
 
 func (f *Files) Close() {
-	f.message.Reset()
+	f.message.reset()
 }
 
 const (

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -282,31 +282,6 @@ func (m *Message) getString() string {
 
 	index := bytes.IndexByte(b.Bytes[b.Offset:], 0)
 	if index == -1 {
-		// Check if the string overflows in the dynamic buffer.
-		if b == &m.body1 && m.body2.Bytes != nil {
-			// Assert that this is the first read of the dynamic buffer.
-			if m.body2.Offset != 0 {
-				panic("static buffer read after dynamic buffer one")
-			}
-			index = bytes.IndexByte(m.body2.Bytes[0:], 0)
-			if index != -1 {
-				// We found the trailing part of the string.
-				data := b.Bytes[b.Offset:]
-				data = append(data, m.body2.Bytes[0:index]...)
-
-				index++
-
-				if trailing := index % messageWordSize; trailing != 0 {
-					// Account for padding, moving index to the next word boundary.
-					index += messageWordSize - trailing
-				}
-
-				m.body1.Offset = len(m.body1.Bytes)
-				m.body2.Advance(index)
-
-				return string(data)
-			}
-		}
 		panic("no string found")
 	}
 	s := string(b.Bytes[b.Offset : b.Offset+index])

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -276,24 +276,11 @@ func (m *Message) finalize() {
 }
 
 func (m *Message) bufferForPut(size int) *buffer {
-	if m.body2.Bytes != nil {
-		if (m.body2.Offset + size) > len(m.body2.Bytes) {
-			// Grow body2.
-			//
-			// TODO: find a good grow strategy.
-			bytes := make([]byte, m.body2.Offset+size)
-			copy(bytes, m.body2.Bytes)
-			m.body2.Bytes = bytes
-		}
-
-		return &m.body2
-	}
-
-	if (m.body1.Offset + size) > len(m.body1.Bytes) {
-		m.body2.Bytes = make([]byte, size)
-		m.body2.Offset = 0
-
-		return &m.body2
+	for (m.body1.Offset + size) > len(m.body1.Bytes) {
+		// Grow message buffer.
+		bytes := make([]byte, len(m.body1.Bytes)*2)
+		copy(bytes, m.body1.Bytes)
+		m.body1.Bytes = bytes
 	}
 
 	return &m.body1

--- a/internal/protocol/message_export_test.go
+++ b/internal/protocol/message_export_test.go
@@ -6,5 +6,4 @@ func (m *Message) Body1() ([]byte, int) {
 
 func (m *Message) Rewind() {
 	m.body1.Offset = 0
-	m.body2.Offset = 0
 }

--- a/internal/protocol/message_export_test.go
+++ b/internal/protocol/message_export_test.go
@@ -1,9 +1,9 @@
 package protocol
 
-func (m *Message) Body1() ([]byte, int) {
-	return m.body1.Bytes, m.body1.Offset
+func (m *Message) Body() ([]byte, int) {
+	return m.body.Bytes, m.body.Offset
 }
 
 func (m *Message) Rewind() {
-	m.body1.Offset = 0
+	m.body.Offset = 0
 }

--- a/internal/protocol/message_internal_test.go
+++ b/internal/protocol/message_internal_test.go
@@ -39,7 +39,7 @@ func TestMessage_putBlob(t *testing.T) {
 			assert.Equal(t, bytes[8:len(c.Blob)+8], c.Blob)
 			assert.Equal(t, offset, c.Offset)
 
-			message.Reset()
+			message.reset()
 		})
 	}
 }
@@ -66,7 +66,7 @@ func TestMessage_putString(t *testing.T) {
 			assert.Equal(t, string(bytes[:len(c.String)]), c.String)
 			assert.Equal(t, offset, c.Offset)
 
-			message.Reset()
+			message.reset()
 		})
 	}
 }
@@ -189,7 +189,7 @@ func BenchmarkMessage_putString(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		message.Reset()
+		message.reset()
 		message.putString("hello")
 	}
 }
@@ -201,7 +201,7 @@ func BenchmarkMessage_putUint64(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		message.Reset()
+		message.reset()
 		message.putUint64(270)
 	}
 }

--- a/internal/protocol/message_internal_test.go
+++ b/internal/protocol/message_internal_test.go
@@ -13,7 +13,7 @@ import (
 func TestMessage_StaticBytesAlignment(t *testing.T) {
 	message := Message{}
 	message.Init(4096)
-	pointer := uintptr(unsafe.Pointer(&message.body1.Bytes))
+	pointer := uintptr(unsafe.Pointer(&message.body.Bytes))
 	assert.Equal(t, pointer%messageWordSize, uintptr(0))
 }
 
@@ -34,7 +34,7 @@ func TestMessage_putBlob(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", c.Offset), func(t *testing.T) {
 			message.putBlob(c.Blob)
 
-			bytes, offset := message.Body1()
+			bytes, offset := message.Body()
 
 			assert.Equal(t, bytes[8:len(c.Blob)+8], c.Blob)
 			assert.Equal(t, offset, c.Offset)
@@ -61,7 +61,7 @@ func TestMessage_putString(t *testing.T) {
 		t.Run(c.String, func(t *testing.T) {
 			message.putString(c.String)
 
-			bytes, offset := message.Body1()
+			bytes, offset := message.Body()
 
 			assert.Equal(t, string(bytes[:len(c.String)]), c.String)
 			assert.Equal(t, offset, c.Offset)
@@ -79,7 +79,7 @@ func TestMessage_putUint8(t *testing.T) {
 
 	message.putUint8(v)
 
-	bytes, offset := message.Body1()
+	bytes, offset := message.Body()
 
 	assert.Equal(t, bytes[0], byte(v))
 
@@ -94,7 +94,7 @@ func TestMessage_putUint16(t *testing.T) {
 
 	message.putUint16(v)
 
-	bytes, offset := message.Body1()
+	bytes, offset := message.Body()
 
 	assert.Equal(t, bytes[0], byte((v & 0x00ff)))
 	assert.Equal(t, bytes[1], byte((v&0xff00)>>8))
@@ -110,7 +110,7 @@ func TestMessage_putUint32(t *testing.T) {
 
 	message.putUint32(v)
 
-	bytes, offset := message.Body1()
+	bytes, offset := message.Body()
 
 	assert.Equal(t, bytes[0], byte((v & 0x000000ff)))
 	assert.Equal(t, bytes[1], byte((v&0x0000ff00)>>8))
@@ -128,7 +128,7 @@ func TestMessage_putUint64(t *testing.T) {
 
 	message.putUint64(v)
 
-	bytes, offset := message.Body1()
+	bytes, offset := message.Body()
 
 	assert.Equal(t, bytes[0], byte((v & 0x00000000000000ff)))
 	assert.Equal(t, bytes[1], byte((v&0x000000000000ff00)>>8))
@@ -161,7 +161,7 @@ func TestMessage_putNamedValues(t *testing.T) {
 
 	message.putNamedValues(values)
 
-	bytes, offset := message.Body1()
+	bytes, offset := message.Body()
 
 	assert.Equal(t, 96, offset)
 	assert.Equal(t, bytes[0], byte(7))
@@ -229,7 +229,7 @@ func TestMessage_getString(t *testing.T) {
 
 			s := message.getString()
 
-			_, offset := message.Body1()
+			_, offset := message.Body()
 
 			assert.Equal(t, s, c.String)
 			assert.Equal(t, offset, c.Offset)
@@ -259,7 +259,7 @@ func TestMessage_getBlob(t *testing.T) {
 
 			bytes := message.getBlob()
 
-			_, offset := message.Body1()
+			_, offset := message.Body()
 
 			assert.Equal(t, bytes, c.Blob)
 			assert.Equal(t, offset, c.Offset)
@@ -285,5 +285,5 @@ func TestMessage_getString_Overflow_WordBoundary(t *testing.T) {
 	s := message.getString()
 	assert.Equal(t, "abcdefghilmnopqr", s)
 
-	assert.Equal(t, 32, message.body1.Offset)
+	assert.Equal(t, 32, message.body.Offset)
 }

--- a/internal/protocol/message_internal_test.go
+++ b/internal/protocol/message_internal_test.go
@@ -285,6 +285,5 @@ func TestMessage_getString_Overflow_WordBoundary(t *testing.T) {
 	s := message.getString()
 	assert.Equal(t, "abcdefghilmnopqr", s)
 
-	assert.Equal(t, 8, message.body1.Offset)
-	assert.Equal(t, 24, message.body2.Offset)
+	assert.Equal(t, 32, message.body1.Offset)
 }

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -140,7 +140,7 @@ func (p *Protocol) sendHeader(req *Message) error {
 }
 
 func (p *Protocol) sendBody(req *Message) error {
-	buf := req.body1.Bytes[:req.body1.Offset]
+	buf := req.body.Bytes[:req.body.Offset]
 	n, err := p.conn.Write(buf)
 	if err != nil {
 		return errors.Wrap(err, "failed to send static body")
@@ -183,13 +183,13 @@ func (p *Protocol) recvHeader(res *Message) error {
 func (p *Protocol) recvBody(res *Message) error {
 	n := int(res.words) * messageWordSize
 
-	for n > len(res.body1.Bytes) {
+	for n > len(res.body.Bytes) {
 		// Grow message buffer.
-		bytes := make([]byte, len(res.body1.Bytes)*2)
-		res.body1.Bytes = bytes
+		bytes := make([]byte, len(res.body.Bytes)*2)
+		res.body.Bytes = bytes
 	}
 
-	buf := res.body1.Bytes[:n]
+	buf := res.body.Bytes[:n]
 
 	if err := p.recvPeek(buf); err != nil {
 		return errors.Wrap(err, "failed to read body")

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -154,20 +154,6 @@ func (p *Protocol) sendBody(req *Message) error {
 		return errors.Wrap(io.ErrShortWrite, "failed to write body")
 	}
 
-	if req.body2.Bytes == nil {
-		return nil
-	}
-
-	buf = req.body2.Bytes[:req.body2.Offset]
-	n, err = p.conn.Write(buf)
-	if err != nil {
-		return errors.Wrap(err, "failed to send dynamic body")
-	}
-
-	if n != len(buf) {
-		return errors.Wrap(io.ErrShortWrite, "failed to write body")
-	}
-
 	return nil
 }
 

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -87,8 +87,6 @@ func (p *Protocol) Interrupt(ctx context.Context, request *Message, response *Me
 		defer p.conn.SetDeadline(time.Time{})
 	}
 
-	defer request.Reset()
-
 	EncodeInterrupt(request, 0)
 
 	if err := p.send(request); err != nil {
@@ -97,12 +95,10 @@ func (p *Protocol) Interrupt(ctx context.Context, request *Message, response *Me
 
 	for {
 		if err := p.recv(response); err != nil {
-			response.Reset()
 			return errors.Wrap(err, "failed to receive response")
 		}
 
 		mtype, _ := response.getHeader()
-		response.Reset()
 
 		if mtype == ResponseEmpty {
 			break
@@ -158,6 +154,8 @@ func (p *Protocol) sendBody(req *Message) error {
 }
 
 func (p *Protocol) recv(res *Message) error {
+	res.reset()
+
 	if err := p.recvHeader(res); err != nil {
 		return errors.Wrap(err, "failed to receive header")
 	}

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -44,9 +44,6 @@ func TestProtocol_RequestWithDynamicBuffer(t *testing.T) {
 	id, err := protocol.DecodeDb(&response)
 	require.NoError(t, err)
 
-	request.Reset()
-	response.Reset()
-
 	sql := `
 CREATE TABLE foo (n INT);
 CREATE TABLE bar (n INT);
@@ -70,9 +67,6 @@ func TestProtocol_Prepare(t *testing.T) {
 
 	db, err := protocol.DecodeDb(&response)
 	require.NoError(t, err)
-
-	request.Reset()
-	response.Reset()
 
 	protocol.EncodePrepare(&request, uint64(db), "CREATE TABLE test (n INT)")
 

--- a/internal/protocol/request.go
+++ b/internal/protocol/request.go
@@ -7,7 +7,7 @@ package protocol
 
 // EncodeLeader encodes a Leader request.
 func EncodeLeader(request *Message) {
-    request.Reset()
+	request.reset()
 	request.putUint64(0)
 
 	request.putHeader(RequestLeader)
@@ -15,7 +15,7 @@ func EncodeLeader(request *Message) {
 
 // EncodeClient encodes a Client request.
 func EncodeClient(request *Message, id uint64) {
-    request.Reset()
+	request.reset()
 	request.putUint64(id)
 
 	request.putHeader(RequestClient)
@@ -23,7 +23,7 @@ func EncodeClient(request *Message, id uint64) {
 
 // EncodeHeartbeat encodes a Heartbeat request.
 func EncodeHeartbeat(request *Message, timestamp uint64) {
-    request.Reset()
+	request.reset()
 	request.putUint64(timestamp)
 
 	request.putHeader(RequestHeartbeat)
@@ -31,7 +31,7 @@ func EncodeHeartbeat(request *Message, timestamp uint64) {
 
 // EncodeOpen encodes a Open request.
 func EncodeOpen(request *Message, name string, flags uint64, vfs string) {
-    request.Reset()
+	request.reset()
 	request.putString(name)
 	request.putUint64(flags)
 	request.putString(vfs)
@@ -41,7 +41,7 @@ func EncodeOpen(request *Message, name string, flags uint64, vfs string) {
 
 // EncodePrepare encodes a Prepare request.
 func EncodePrepare(request *Message, db uint64, sql string) {
-    request.Reset()
+	request.reset()
 	request.putUint64(db)
 	request.putString(sql)
 
@@ -50,7 +50,7 @@ func EncodePrepare(request *Message, db uint64, sql string) {
 
 // EncodeExec encodes a Exec request.
 func EncodeExec(request *Message, db uint32, stmt uint32, values NamedValues) {
-    request.Reset()
+	request.reset()
 	request.putUint32(db)
 	request.putUint32(stmt)
 	request.putNamedValues(values)
@@ -60,7 +60,7 @@ func EncodeExec(request *Message, db uint32, stmt uint32, values NamedValues) {
 
 // EncodeQuery encodes a Query request.
 func EncodeQuery(request *Message, db uint32, stmt uint32, values NamedValues) {
-    request.Reset()
+	request.reset()
 	request.putUint32(db)
 	request.putUint32(stmt)
 	request.putNamedValues(values)
@@ -70,7 +70,7 @@ func EncodeQuery(request *Message, db uint32, stmt uint32, values NamedValues) {
 
 // EncodeFinalize encodes a Finalize request.
 func EncodeFinalize(request *Message, db uint32, stmt uint32) {
-    request.Reset()
+	request.reset()
 	request.putUint32(db)
 	request.putUint32(stmt)
 
@@ -79,7 +79,7 @@ func EncodeFinalize(request *Message, db uint32, stmt uint32) {
 
 // EncodeExecSQL encodes a ExecSQL request.
 func EncodeExecSQL(request *Message, db uint64, sql string, values NamedValues) {
-    request.Reset()
+	request.reset()
 	request.putUint64(db)
 	request.putString(sql)
 	request.putNamedValues(values)
@@ -89,7 +89,7 @@ func EncodeExecSQL(request *Message, db uint64, sql string, values NamedValues) 
 
 // EncodeQuerySQL encodes a QuerySQL request.
 func EncodeQuerySQL(request *Message, db uint64, sql string, values NamedValues) {
-    request.Reset()
+	request.reset()
 	request.putUint64(db)
 	request.putString(sql)
 	request.putNamedValues(values)
@@ -99,7 +99,7 @@ func EncodeQuerySQL(request *Message, db uint64, sql string, values NamedValues)
 
 // EncodeInterrupt encodes a Interrupt request.
 func EncodeInterrupt(request *Message, db uint64) {
-    request.Reset()
+	request.reset()
 	request.putUint64(db)
 
 	request.putHeader(RequestInterrupt)
@@ -107,7 +107,7 @@ func EncodeInterrupt(request *Message, db uint64) {
 
 // EncodeAdd encodes a Add request.
 func EncodeAdd(request *Message, id uint64, address string) {
-    request.Reset()
+	request.reset()
 	request.putUint64(id)
 	request.putString(address)
 
@@ -116,7 +116,7 @@ func EncodeAdd(request *Message, id uint64, address string) {
 
 // EncodeAssign encodes a Assign request.
 func EncodeAssign(request *Message, id uint64, role uint64) {
-    request.Reset()
+	request.reset()
 	request.putUint64(id)
 	request.putUint64(role)
 
@@ -125,7 +125,7 @@ func EncodeAssign(request *Message, id uint64, role uint64) {
 
 // EncodeRemove encodes a Remove request.
 func EncodeRemove(request *Message, id uint64) {
-    request.Reset()
+	request.reset()
 	request.putUint64(id)
 
 	request.putHeader(RequestRemove)
@@ -133,7 +133,7 @@ func EncodeRemove(request *Message, id uint64) {
 
 // EncodeDump encodes a Dump request.
 func EncodeDump(request *Message, name string) {
-    request.Reset()
+	request.reset()
 	request.putString(name)
 
 	request.putHeader(RequestDump)
@@ -141,7 +141,7 @@ func EncodeDump(request *Message, name string) {
 
 // EncodeCluster encodes a Cluster request.
 func EncodeCluster(request *Message, format uint64) {
-    request.Reset()
+	request.reset()
 	request.putUint64(format)
 
 	request.putHeader(RequestCluster)
@@ -149,7 +149,7 @@ func EncodeCluster(request *Message, format uint64) {
 
 // EncodeTransfer encodes a Transfer request.
 func EncodeTransfer(request *Message, id uint64) {
-    request.Reset()
+	request.reset()
 	request.putUint64(id)
 
 	request.putHeader(RequestTransfer)

--- a/internal/protocol/request.go
+++ b/internal/protocol/request.go
@@ -7,6 +7,7 @@ package protocol
 
 // EncodeLeader encodes a Leader request.
 func EncodeLeader(request *Message) {
+    request.Reset()
 	request.putUint64(0)
 
 	request.putHeader(RequestLeader)
@@ -14,6 +15,7 @@ func EncodeLeader(request *Message) {
 
 // EncodeClient encodes a Client request.
 func EncodeClient(request *Message, id uint64) {
+    request.Reset()
 	request.putUint64(id)
 
 	request.putHeader(RequestClient)
@@ -21,6 +23,7 @@ func EncodeClient(request *Message, id uint64) {
 
 // EncodeHeartbeat encodes a Heartbeat request.
 func EncodeHeartbeat(request *Message, timestamp uint64) {
+    request.Reset()
 	request.putUint64(timestamp)
 
 	request.putHeader(RequestHeartbeat)
@@ -28,6 +31,7 @@ func EncodeHeartbeat(request *Message, timestamp uint64) {
 
 // EncodeOpen encodes a Open request.
 func EncodeOpen(request *Message, name string, flags uint64, vfs string) {
+    request.Reset()
 	request.putString(name)
 	request.putUint64(flags)
 	request.putString(vfs)
@@ -37,6 +41,7 @@ func EncodeOpen(request *Message, name string, flags uint64, vfs string) {
 
 // EncodePrepare encodes a Prepare request.
 func EncodePrepare(request *Message, db uint64, sql string) {
+    request.Reset()
 	request.putUint64(db)
 	request.putString(sql)
 
@@ -45,6 +50,7 @@ func EncodePrepare(request *Message, db uint64, sql string) {
 
 // EncodeExec encodes a Exec request.
 func EncodeExec(request *Message, db uint32, stmt uint32, values NamedValues) {
+    request.Reset()
 	request.putUint32(db)
 	request.putUint32(stmt)
 	request.putNamedValues(values)
@@ -54,6 +60,7 @@ func EncodeExec(request *Message, db uint32, stmt uint32, values NamedValues) {
 
 // EncodeQuery encodes a Query request.
 func EncodeQuery(request *Message, db uint32, stmt uint32, values NamedValues) {
+    request.Reset()
 	request.putUint32(db)
 	request.putUint32(stmt)
 	request.putNamedValues(values)
@@ -63,6 +70,7 @@ func EncodeQuery(request *Message, db uint32, stmt uint32, values NamedValues) {
 
 // EncodeFinalize encodes a Finalize request.
 func EncodeFinalize(request *Message, db uint32, stmt uint32) {
+    request.Reset()
 	request.putUint32(db)
 	request.putUint32(stmt)
 
@@ -71,6 +79,7 @@ func EncodeFinalize(request *Message, db uint32, stmt uint32) {
 
 // EncodeExecSQL encodes a ExecSQL request.
 func EncodeExecSQL(request *Message, db uint64, sql string, values NamedValues) {
+    request.Reset()
 	request.putUint64(db)
 	request.putString(sql)
 	request.putNamedValues(values)
@@ -80,6 +89,7 @@ func EncodeExecSQL(request *Message, db uint64, sql string, values NamedValues) 
 
 // EncodeQuerySQL encodes a QuerySQL request.
 func EncodeQuerySQL(request *Message, db uint64, sql string, values NamedValues) {
+    request.Reset()
 	request.putUint64(db)
 	request.putString(sql)
 	request.putNamedValues(values)
@@ -89,6 +99,7 @@ func EncodeQuerySQL(request *Message, db uint64, sql string, values NamedValues)
 
 // EncodeInterrupt encodes a Interrupt request.
 func EncodeInterrupt(request *Message, db uint64) {
+    request.Reset()
 	request.putUint64(db)
 
 	request.putHeader(RequestInterrupt)
@@ -96,6 +107,7 @@ func EncodeInterrupt(request *Message, db uint64) {
 
 // EncodeAdd encodes a Add request.
 func EncodeAdd(request *Message, id uint64, address string) {
+    request.Reset()
 	request.putUint64(id)
 	request.putString(address)
 
@@ -104,6 +116,7 @@ func EncodeAdd(request *Message, id uint64, address string) {
 
 // EncodeAssign encodes a Assign request.
 func EncodeAssign(request *Message, id uint64, role uint64) {
+    request.Reset()
 	request.putUint64(id)
 	request.putUint64(role)
 
@@ -112,6 +125,7 @@ func EncodeAssign(request *Message, id uint64, role uint64) {
 
 // EncodeRemove encodes a Remove request.
 func EncodeRemove(request *Message, id uint64) {
+    request.Reset()
 	request.putUint64(id)
 
 	request.putHeader(RequestRemove)
@@ -119,6 +133,7 @@ func EncodeRemove(request *Message, id uint64) {
 
 // EncodeDump encodes a Dump request.
 func EncodeDump(request *Message, name string) {
+    request.Reset()
 	request.putString(name)
 
 	request.putHeader(RequestDump)
@@ -126,6 +141,7 @@ func EncodeDump(request *Message, name string) {
 
 // EncodeCluster encodes a Cluster request.
 func EncodeCluster(request *Message, format uint64) {
+    request.Reset()
 	request.putUint64(format)
 
 	request.putHeader(RequestCluster)
@@ -133,6 +149,7 @@ func EncodeCluster(request *Message, format uint64) {
 
 // EncodeTransfer encodes a Transfer request.
 func EncodeTransfer(request *Message, id uint64) {
+    request.Reset()
 	request.putUint64(id)
 
 	request.putHeader(RequestTransfer)

--- a/internal/protocol/schema.sh
+++ b/internal/protocol/schema.sh
@@ -54,7 +54,7 @@ if [ "$entity" = "--request" ]; then
 
 // Encode${cmd} encodes a $cmd request.
 func Encode${cmd}(request *Message${args}) {
-    request.Reset()
+	request.reset()
 EOF
 
     for i in "${@}"

--- a/internal/protocol/schema.sh
+++ b/internal/protocol/schema.sh
@@ -54,6 +54,7 @@ if [ "$entity" = "--request" ]; then
 
 // Encode${cmd} encodes a $cmd request.
 func Encode${cmd}(request *Message${args}) {
+    request.Reset()
 EOF
 
     for i in "${@}"


### PR DESCRIPTION
The previous implementation was using 2 buffers for sending and receiving messages: a one-off allocated buffer of fixed size reused across messages (to avoid re-allocation) and a dynamically sized one allocated for sending or receiving specific messages exceeding the size of the one-off buffer.

That was an optimization that probably didn't buy much performance, and apparently was the source of some bugs surfaced in k8s.

This branch moves to a single buffer, which is grown as needed and not re-allocated. This should maintain the performance benefits of the previous approach (however small, this would need to be measured), but simplifies the underlying logic making it more robust. The only downside is that this buffer is never shrunk once grown, if that becomes a problem in practice we can put in place some mechanism to shrink it.