### PR TITLE
Update some error constants to match SQLite 3.32.1+replication4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ script:
   - $GOPATH/bin/goveralls -coverprofile overalls.coverprofile -service=travis-ci
 
 go:
-  - "1.12"
   - "1.13"
+  - "1.14"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
   - go vet -tags libsqlite3 ./...
   - golint
   - deadcode
+  - export GO_DQLITE_MULTITHREAD=1
   - project=github.com/canonical/go-dqlite
   - $GOPATH/bin/overalls -project $project -covermode=count -- -tags libsqlite3 -timeout 240s
   - $GOPATH/bin/goveralls -coverprofile overalls.coverprofile -service=travis-ci

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -47,8 +47,8 @@ type Error = protocol.Error
 const (
 	ErrBusy                = 5
 	errIoErr               = 10
-	errIoErrNotLeader      = errIoErr | 32<<8
-	errIoErrLeadershipLost = errIoErr | (33 << 8)
+	errIoErrNotLeader      = errIoErr | 40<<8
+	errIoErrLeadershipLost = errIoErr | (41 << 8)
 )
 
 // Option can be used to tweak driver parameters.


### PR DESCRIPTION
The values of some constants had to be bumped since they were conflicting with
upstream.