### PR TITLE
Make initial cluster joining asynchronous

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .sqlite
 cmd/dqlite/dqlite
 cmd/dqlite-demo/dqlite-demo
-demo
+dqlite
+dqlite-demo
 profile.coverprofile
 overalls.coverprofile

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ script:
   - project=github.com/canonical/go-dqlite
   - $GOPATH/bin/overalls -project $project -covermode=count -- -tags libsqlite3 -timeout 240s
   - $GOPATH/bin/goveralls -coverprofile overalls.coverprofile -service=travis-ci
+  - VERBOSE=1 ./test/dqlite-demo.sh
 
 go:
   - "1.13"

--- a/app/app.go
+++ b/app/app.go
@@ -345,11 +345,12 @@ func (a *App) run(ctx context.Context, join bool) {
 		}
 	}
 
+	nextUpdate := time.Duration(0)
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(30 * time.Second):
+		case <-time.After(nextUpdate):
 			cli, err := a.Leader(ctx)
 			if err != nil {
 				continue
@@ -359,6 +360,7 @@ func (a *App) run(ctx context.Context, join bool) {
 				continue
 			}
 			a.store.Set(ctx, servers)
+			nextUpdate = 30 * time.Second
 		}
 	}
 }

--- a/app/files.go
+++ b/app/files.go
@@ -1,0 +1,75 @@
+package app
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+)
+
+const (
+	// Store the node ID and address.
+	infoYamlFile = "info.yaml"
+
+	// The node store file.
+	storeFile = "cluster.yaml"
+)
+
+// Return true if the given file exists in the given directory.
+func fileExists(dir, file string) (bool, error) {
+	path := filepath.Join(dir, file)
+
+	if _, err := os.Stat(path); err != nil {
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("check if %s exists: %w", file, err)
+		}
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// Write a file in the given directory.
+func fileWrite(dir, file string, data []byte) error {
+	path := filepath.Join(dir, file)
+
+	if err := ioutil.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("write %s: %w", file, err)
+	}
+
+	return nil
+}
+
+// Marshal the given object as YAML into the given file.
+func fileMarshal(dir, file string, object interface{}) error {
+	data, err := yaml.Marshal(object)
+	if err != nil {
+		return fmt.Errorf("marshall %s: %w", file, err)
+	}
+	if err := fileWrite(dir, file, data); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Unmarshal the given YAML file into the given object.
+func fileUnmarshal(dir, file string, object interface{}) error {
+	path := filepath.Join(dir, file)
+
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", file, err)
+	}
+	if err := yaml.Unmarshal(data, object); err != nil {
+		return fmt.Errorf("unmarshall %s: %w", file, err)
+	}
+
+	return nil
+}
+
+// Remove a file in the given directory.
+func fileRemove(dir, file string) error {
+	return os.Remove(filepath.Join(dir, file))
+}

--- a/app/files.go
+++ b/app/files.go
@@ -11,10 +11,15 @@ import (
 
 const (
 	// Store the node ID and address.
-	infoYamlFile = "info.yaml"
+	infoFile = "info.yaml"
 
 	// The node store file.
 	storeFile = "cluster.yaml"
+
+	// This is a "flag" file to signal when a brand new node needs to join
+	// the cluster. In case the node doesn't successfully make it to join
+	// the cluster first time it's started, it will re-try the next time.
+	joinFile = "join"
 )
 
 // Return true if the given file exists in the given directory.

--- a/cmd/dqlite-demo/dqlite-demo.go
+++ b/cmd/dqlite-demo/dqlite-demo.go
@@ -24,6 +24,7 @@ func main() {
 	var db string
 	var join *[]string
 	var dir string
+	var verbose bool
 
 	cmd := &cobra.Command{
 		Use:   "dqlite-demo",
@@ -33,7 +34,10 @@ func main() {
 Complete documentation is available at https://github.com/canonical/go-dqlite`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logFunc := func(l client.LogLevel, format string, a ...interface{}) {
-				log.Printf(fmt.Sprintf("Dqlite: %s: %s\n", l.String(), format), a...)
+				if !verbose {
+					return
+				}
+				log.Printf(fmt.Sprintf("%s: %s: %s\n", api, l.String(), format), a...)
 			}
 			dir := filepath.Join(dir, db)
 			if err := os.MkdirAll(dir, 0755); err != nil {
@@ -104,6 +108,7 @@ Complete documentation is available at https://github.com/canonical/go-dqlite`,
 	flags.StringVarP(&db, "db", "d", "", "address used for internal database replication")
 	join = flags.StringSliceP("join", "j", nil, "database addresses of existing nodes")
 	flags.StringVarP(&dir, "dir", "D", "/tmp/dqlite-demo", "data directory")
+	flags.BoolVarP(&verbose, "verbose", "v", false, "verbose logging")
 
 	cmd.MarkFlagRequired("api")
 	cmd.MarkFlagRequired("db")

--- a/test/dqlite-demo.sh
+++ b/test/dqlite-demo.sh
@@ -1,0 +1,127 @@
+#!/bin/sh -eu
+#
+# Test the dqlite-demo application.
+
+GO=${GO:-go}
+VERBOSE=${VERBOSE:-0}
+
+$GO build -tags libsqlite3 ./cmd/dqlite-demo/
+$GO build -tags libsqlite3 ./cmd/dqlite/
+
+DIR=$(mktemp -d)
+
+start_node() {
+    n="${1}"
+    pidfile="${DIR}/pid.${n}"
+    join="${2}"
+    verbose=""
+
+    if [ $VERBOSE -eq 1 ]; then
+        verbose="--verbose"
+    fi
+
+    ./dqlite-demo --dir $DIR --api=127.0.0.1:800${n} --db=127.0.0.1:900${n} $join $verbose &
+    echo "${!}" > "${pidfile}"
+
+    i=0
+    while ! nc -z 127.0.0.1 800${n} 2>/dev/null; do
+        i=$(expr $i + 1)
+        sleep 0.1
+        if [ $i -eq 10 ]; then
+            echo "Error: node ${n} not yet up after a second"
+            exit 1
+        fi
+    done
+}
+
+kill_node() {
+    n=$1
+    pidfile="${DIR}/pid.${n}"
+
+    if ! [ -e $pidfile ]; then
+        return
+    fi
+
+    pid=$(cat ${pidfile})
+
+    kill -TERM $pid
+    wait $pid
+
+    rm ${pidfile}
+}
+
+set_up_node() {
+    n=$1
+    join=""
+    if [ $n -ne 1 ]; then
+        join=--join=127.0.0.1:9001
+    fi
+
+    echo "=> Set up dqlite-demo node $n"
+
+    start_node "${n}" "${join}"
+}
+
+tear_down_node() {
+    n=$1
+
+    echo "=> Tear down dqlite-demo node $n"
+
+    kill_node $n
+}
+
+set_up() {
+    echo "=> Set up dqlite-demo cluster"
+    set_up_node 1
+    set_up_node 2
+    set_up_node 3
+}
+
+tear_down() {
+    err=$?
+    trap '' HUP INT TERM
+
+    echo "=> Tear down dqlite-demo cluster"
+    tear_down_node 3
+    tear_down_node 2
+    tear_down_node 1
+
+    rm -rf $DIR
+
+    exit $err
+}
+
+sig_handler() {
+    trap '' EXIT
+    tear_down
+}
+
+trap tear_down EXIT
+trap sig_handler HUP INT TERM
+
+set_up
+
+echo "=> Start test"
+
+echo "=> Put key to node 1"
+if [ "$(curl -s -X PUT -d my-key http://127.0.0.1:8001/my-value)" != "done" ]; then
+    echo "Error: put key to node 1"
+fi
+
+echo "=> Get key from node 1"
+if [ "$(curl -s http://127.0.0.1:8001/my-value)" != "my-key" ]; then
+    echo "Error: get key from node 1"
+fi
+
+# Wait a bit for membership to settle
+sleep 1
+
+echo "=> Kill node 1"
+kill_node 1
+
+echo "=> Get key from node 2"
+if [ "$(curl -s http://127.0.0.1:8002/my-value)" != "my-key" ]; then
+    echo "Error: get key from node 2"
+fi
+
+echo "=> Test successful"


### PR DESCRIPTION
When a non-bootstrap node first starts it will try to join the cluster asynchronously, so it can retry in case of failures and it won't block the `app.New()` call.

An integration test has been added as well to validate that the demo program behaves as advertised in `README.md`.