### PR TITLE
Don't join as Voter if there are less than 3 nodes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -35,6 +35,7 @@ type App struct {
 	stop            context.CancelFunc // Signal App.run() to stop.
 	proxyCh         chan struct{}      // Waits for App.proxy() to return.
 	runCh           chan struct{}      // Waits for App.run() to return.
+	voters          int
 }
 
 // New creates a new application node.
@@ -193,6 +194,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 		tls:             o.TLS,
 		stop:            stop,
 		runCh:           make(chan struct{}, 0),
+		voters:          o.Voters,
 	}
 
 	// Start the proxy if a TLS configuration was provided.

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -32,27 +32,20 @@ func TestNew_PristineJoiner(t *testing.T) {
 	app1, cleanup := newApp(t, app.WithAddress(addr1))
 	defer cleanup()
 
-	_, cleanup = newApp(t, app.WithAddress(addr2), app.WithCluster([]string{addr1}))
+	app2, cleanup := newApp(t, app.WithAddress(addr2), app.WithCluster([]string{addr1}))
 	defer cleanup()
 
-	// Eventually the joining nodes appear in the cluster list.
+	require.NoError(t, app2.Ready(context.Background()))
+
+	// Wait for initial tasks to complete, and the joining node to appear
+	// in the cluster list.
 	cli, err := app1.Leader(context.Background())
 	require.NoError(t, err)
 
-	joined := false
-	for i := 0; i < 20; i++ {
-		time.Sleep(50 * time.Millisecond)
-		cluster, err := cli.Cluster(context.Background())
-		require.NoError(t, err)
-		if len(cluster) == 2 {
-			assert.Equal(t, addr1, cluster[0].Address)
-			assert.Equal(t, addr2, cluster[1].Address)
-			joined = true
-			break
-		}
-	}
-
-	assert.True(t, joined)
+	cluster, err := cli.Cluster(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, addr1, cluster[0].Address)
+	assert.Equal(t, addr2, cluster[1].Address)
 }
 
 // Open a database on a fresh one-node cluster.
@@ -106,6 +99,20 @@ func TestProxy_Error(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	conn.Close()
 	time.Sleep(250 * time.Millisecond)
+}
+
+// If the given context is cancelled before initial tasks are completed, an
+// error is returned.
+func TestReady_Cancel(t *testing.T) {
+	app, cleanup := newApp(t, app.WithAddress("127.0.0.1:9002"), app.WithCluster([]string{"127.0.0.1:9001"}))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := app.Ready(ctx)
+
+	assert.Equal(t, ctx.Err(), err)
 }
 
 func newApp(t *testing.T, options ...app.Option) (*app.App, func()) {

--- a/app/options.go
+++ b/app/options.go
@@ -58,6 +58,26 @@ func WithTLS(listen *tls.Config, dial *tls.Config) Option {
 	}
 }
 
+// WithVoters sets the number of nodes in the cluster that should have the
+// Voter role.
+//
+// When a new node is added to the cluster or it is started again after a
+// shutdown it will be assigned the Voter role in case the current number of
+// voters is below n.
+//
+// Similarly when a node with the Voter role is shutdown gracefully it will try
+// to transfer its Voter role to another non-Voter role, if one is available.
+//
+//  All App instances in a cluster must be created with the same WithVoters
+//  setting.
+//
+// The default value is 3.
+func WithVoters(n int) Option {
+	return func(options *options) {
+		options.Voters = n
+	}
+}
+
 // WithLogFunc sets a custom log function.
 func WithLogFunc(log client.LogFunc) Option {
 	return func(options *options) {
@@ -75,6 +95,7 @@ type options struct {
 	Cluster []string
 	Log     client.LogFunc
 	TLS     *tlsSetup
+	Voters  int
 }
 
 // Create a options object with sane defaults.
@@ -82,6 +103,7 @@ func defaultOptions() *options {
 	return &options{
 		Address: defaultAddress(),
 		Log:     defaultLogFunc,
+		Voters:  3,
 	}
 }
 

--- a/cmd/dqlite-demo/dqlite-demo.go
+++ b/cmd/dqlite-demo/dqlite-demo.go
@@ -33,18 +33,22 @@ func main() {
 
 Complete documentation is available at https://github.com/canonical/go-dqlite`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := filepath.Join(dir, db)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				return errors.Wrapf(err, "can't create %s", dir)
+			}
 			logFunc := func(l client.LogLevel, format string, a ...interface{}) {
 				if !verbose {
 					return
 				}
 				log.Printf(fmt.Sprintf("%s: %s: %s\n", api, l.String(), format), a...)
 			}
-			dir := filepath.Join(dir, db)
-			if err := os.MkdirAll(dir, 0755); err != nil {
-				return errors.Wrapf(err, "can't create %s", dir)
-			}
 			app, err := app.New(dir, app.WithAddress(db), app.WithCluster(*join), app.WithLogFunc(logFunc))
 			if err != nil {
+				return err
+			}
+
+			if err := app.Ready(context.Background()); err != nil {
 				return err
 			}
 

--- a/test/dqlite-demo.sh
+++ b/test/dqlite-demo.sh
@@ -26,9 +26,9 @@ start_node() {
     i=0
     while ! nc -z 127.0.0.1 800${n} 2>/dev/null; do
         i=$(expr $i + 1)
-        sleep 0.1
-        if [ $i -eq 10 ]; then
-            echo "Error: node ${n} not yet up after a second"
+        sleep 0.2
+        if [ $i -eq 25 ]; then
+            echo "Error: node ${n} not yet up after 5 seconds"
             exit 1
         fi
     done
@@ -112,9 +112,6 @@ echo "=> Get key from node 1"
 if [ "$(curl -s http://127.0.0.1:8001/my-value)" != "my-key" ]; then
     echo "Error: get key from node 1"
 fi
-
-# Wait a bit for membership to settle
-sleep 1
 
 echo "=> Kill node 1"
 kill_node 1


### PR DESCRIPTION
This is an initial stab at including in the `app` framework the same goodness we have in LXD and microk8s. Joining nodes will be assigned the `Voter` role only once the cluster reaches 3 nodes. More refinements will follow, as well as handling of edge cases.