### PR TITLE
Add ReconfigureMembership() to force a new raft configuration

### DIFF
--- a/app/example_test.go
+++ b/app/example_test.go
@@ -42,6 +42,7 @@ func Example() {
 
 	fmt.Printf("0x%x %s\n", node.ID(), node.Address())
 	// Output: 0x2dc171858c3155be 127.0.0.1:9001
+	// 0x2dc171858c3155be 127.0.0.1:9001
 }
 
 // After starting the very first node, a second node can be started by passing

--- a/app/options.go
+++ b/app/options.go
@@ -142,7 +142,6 @@ type options struct {
 // Create a options object with sane defaults.
 func defaultOptions() *options {
 	return &options{
-		Address:                  defaultAddress(),
 		Log:                      defaultLogFunc,
 		Voters:                   3,
 		StandBys:                 2,

--- a/cmd/dqlite/dqlite.go
+++ b/cmd/dqlite/dqlite.go
@@ -28,13 +28,30 @@ func main() {
 		Short: "Standard dqlite shell",
 		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			infos := make([]client.NodeInfo, len(*servers))
-			for i, address := range *servers {
-				infos[i].Address = address
+			if len(*servers) == 0 {
+				return fmt.Errorf("no servers provided")
 			}
+			var store client.NodeStore
+			var err error
 
-			store := client.NewInmemNodeStore()
-			store.Set(context.Background(), infos)
+			first := (*servers)[0]
+			if strings.HasPrefix(first, "file://") {
+				if len(*servers) > 1 {
+					return fmt.Errorf("can't mix server store and explicit list")
+				}
+				path := first[len("file://"):]
+				store, err = client.DefaultNodeStore(path)
+				if err != nil {
+					return fmt.Errorf("open servers store: %w", err)
+				}
+			} else {
+				infos := make([]client.NodeInfo, len(*servers))
+				for i, address := range *servers {
+					infos[i].Address = address
+				}
+				store = client.NewInmemNodeStore()
+				store.Set(context.Background(), infos)
+			}
 
 			if (crt != "" && key == "") || (key != "" && crt == "") {
 				return fmt.Errorf("both TLS certificate and key must be given")
@@ -105,7 +122,7 @@ func main() {
 	}
 
 	flags := cmd.Flags()
-	servers = flags.StringSliceP("servers", "s", nil, "comma-separated list of db servers")
+	servers = flags.StringSliceP("servers", "s", nil, "comma-separated list of db servers, or file://<store>")
 	flags.StringVarP(&crt, "cert", "c", "", "public TLS cert")
 	flags.StringVarP(&key, "key", "k", "", "private TLS key")
 	flags.StringVarP(&format, "format", "f", "tabular", "output format (tabular, json)")

--- a/cmd/dqlite/dqlite.go
+++ b/cmd/dqlite/dqlite.go
@@ -21,6 +21,7 @@ func main() {
 	var crt string
 	var key string
 	var servers *[]string
+	var format string
 
 	cmd := &cobra.Command{
 		Use:   "dqlite -s <servers> <database> [command]",
@@ -62,7 +63,7 @@ func main() {
 
 			}
 
-			sh, err := shell.New(args[0], store, shell.WithDialFunc(dial))
+			sh, err := shell.New(args[0], store, shell.WithDialFunc(dial), shell.WithFormat(format))
 			if err != nil {
 				return err
 			}
@@ -107,6 +108,7 @@ func main() {
 	servers = flags.StringSliceP("servers", "s", nil, "comma-separated list of db servers")
 	flags.StringVarP(&crt, "cert", "c", "", "public TLS cert")
 	flags.StringVarP(&key, "key", "k", "", "private TLS key")
+	flags.StringVarP(&format, "format", "f", "tabular", "output format (tabular, json)")
 
 	cmd.MarkFlagRequired("servers")
 

--- a/internal/shell/options.go
+++ b/internal/shell/options.go
@@ -20,9 +20,17 @@ func WithDriverName(name string) Option {
 	}
 }
 
+// WithFormat specifies the output format.
+func WithFormat(format string) Option {
+	return func(options *options) {
+		options.Format = format
+	}
+}
+
 type options struct {
 	Dial       client.DialFunc
 	DriverName string
+	Format     string
 }
 
 // Create a client options object with sane defaults.
@@ -30,5 +38,11 @@ func defaultOptions() *options {
 	return &options{
 		Dial:       client.DefaultDialFunc,
 		DriverName: "dqlite",
+		Format:     formatTabular,
 	}
 }
+
+const (
+	formatTabular = "tabular"
+	formatJson    = "json"
+)

--- a/node.go
+++ b/node.go
@@ -94,6 +94,9 @@ func (s *Node) Start() error {
 }
 
 // Recover a node by forcing a new cluster configuration.
+//
+// DEPRECATED: Use ReconfigureMembership instead, which does not require
+// instantiating a new Node object.
 func (s *Node) Recover(cluster []NodeInfo) error {
 	return s.server.Recover(cluster)
 }
@@ -126,6 +129,20 @@ const BootstrapID = 0x2dc171858c3155be
 // address and the current time.
 func GenerateID(address string) uint64 {
 	return bindings.GenerateID(address)
+}
+
+// ReconfigureMembership can be used to recover a cluster whose majority of
+// nodes have died, and therefore has become unavailable.
+//
+// It forces appending a new configuration to the raft log stored in the given
+// directory, effectively replacing the current configuration.
+func ReconfigureMembership(dir string, cluster []NodeInfo) error {
+	server, err := bindings.NewNode(1, "1", dir)
+	if err != nil {
+		return err
+	}
+	defer server.Close()
+	return server.Recover(cluster)
 }
 
 // Create a options object with sane defaults.


### PR DESCRIPTION
This PR also adds a few other improvements:

- initial support for json output in dqlite shell
- avoid requiring the `WithAddress()` option for restarts
- new .remove command in `dqlite` CLI
- support specifying a store file for the `dqlite` CLI instead of a manual list of nodes