### PR TITLE
Honor failure domains and weights

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,7 +1,7 @@
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
 ((go-mode
-  . ((go-test-args . "-tags libsqlite3 -timeout 60s")
+  . ((go-test-args . "-tags libsqlite3 -timeout 90s")
      (eval
       . (set
 	 (make-local-variable 'flycheck-go-build-tags)

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,4 @@ script:
   - VERBOSE=1 ./test/roles.sh
 
 go:
-  - "1.13"
   - "1.14"

--- a/app/app.go
+++ b/app/app.go
@@ -192,8 +192,8 @@ func New(dir string, options ...Option) (app *App, err error) {
 		return nil, fmt.Errorf("invalid voters %d: must be an odd number greater than 1", o.Voters)
 	}
 
-	if o.StandBys < 0 || o.StandBys%2 != 0 {
-		return nil, fmt.Errorf("invalid stand-bys %d: must be an even number greater than 0", o.StandBys)
+	if o.StandBys%2 == 0 {
+		return nil, fmt.Errorf("invalid stand-bys %d: must be an odd number", o.StandBys)
 	}
 
 	ctx, stop := context.WithCancel(context.Background())

--- a/app/app.go
+++ b/app/app.go
@@ -388,6 +388,11 @@ func (a *App) Leader(ctx context.Context) (*client.Client, error) {
 	return client.FindLeader(ctx, a.store, a.clientOptions()...)
 }
 
+// Client returns a client connected to the local node.
+func (a *App) Client(ctx context.Context) (*client.Client, error) {
+	return client.New(ctx, a.nodeBindAddress)
+}
+
 // Proxy incoming TLS connections.
 func (a *App) proxy() {
 	wg := sync.WaitGroup{}

--- a/app/app.go
+++ b/app/app.go
@@ -163,6 +163,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 		info.ID, info.Address, dir,
 		dqlite.WithBindAddress(nodeBindAddress),
 		dqlite.WithDialFunc(nodeDial),
+		dqlite.WithFailureDomain(o.FailureDomain),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create node: %w", err)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -291,6 +291,50 @@ func TestHandover_Voter(t *testing.T) {
 	assert.Equal(t, client.Voter, cluster[3].Role)
 }
 
+// Transfer voting rights to another online node. Failure domains are taken
+// into account.
+func TestHandover_VoterHonorFailureDomain(t *testing.T) {
+	n := 6
+	apps := make([]*app.App, n)
+
+	for i := 0; i < n; i++ {
+		addr := fmt.Sprintf("127.0.0.1:900%d", i+1)
+		options := []app.Option{
+			app.WithAddress(addr),
+			app.WithFailureDomain(uint64(i % 3)),
+		}
+		if i > 0 {
+			options = append(options, app.WithCluster([]string{"127.0.0.1:9001"}))
+		}
+
+		app, cleanup := newApp(t, options...)
+		defer cleanup()
+
+		require.NoError(t, app.Ready(context.Background()))
+
+		apps[i] = app
+	}
+
+	cli, err := apps[0].Leader(context.Background())
+	require.NoError(t, err)
+	defer cli.Close()
+
+	cluster, err := cli.Cluster(context.Background())
+	require.NoError(t, err)
+
+	require.NoError(t, apps[2].Handover(context.Background()))
+
+	cluster, err = cli.Cluster(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, client.Voter, cluster[0].Role)
+	assert.Equal(t, client.Voter, cluster[1].Role)
+	assert.Equal(t, client.Spare, cluster[2].Role)
+	assert.Equal(t, client.StandBy, cluster[3].Role)
+	assert.Equal(t, client.StandBy, cluster[4].Role)
+	assert.Equal(t, client.Voter, cluster[5].Role)
+}
+
 // Transfer the stand-by role to another online node.
 func TestHandover_StandBy(t *testing.T) {
 	n := 7

--- a/app/options.go
+++ b/app/options.go
@@ -124,6 +124,16 @@ func WithLogFunc(log client.LogFunc) Option {
 	}
 }
 
+// WithFailureDomain sets the node's failure domain.
+//
+// Failure domains are taken into account when deciding which nodes to promote
+// to Voter or StandBy when needed.
+func WithFailureDomain(code uint64) Option {
+	return func(options *options) {
+		options.FailureDomain = code
+	}
+}
+
 type tlsSetup struct {
 	Listen *tls.Config
 	Dial   *tls.Config
@@ -137,6 +147,7 @@ type options struct {
 	Voters                   int
 	StandBys                 int
 	RolesAdjustmentFrequency time.Duration
+	FailureDomain            uint64
 }
 
 // Create a options object with sane defaults.

--- a/app/options.go
+++ b/app/options.go
@@ -96,9 +96,9 @@ func WithVoters(n int) Option {
 // All App instances in a cluster must be created with the same WithStandBys
 // setting.
 //
-// The given value must be an even number greater than zero.
+// The given value must be an odd number.
 //
-// The default value is 2.
+// The default value is 3.
 func WithStandBys(n int) Option {
 	return func(options *options) {
 		options.StandBys = n
@@ -155,7 +155,7 @@ func defaultOptions() *options {
 	return &options{
 		Log:                      defaultLogFunc,
 		Voters:                   3,
-		StandBys:                 2,
+		StandBys:                 3,
 		RolesAdjustmentFrequency: 30 * time.Second,
 	}
 }

--- a/app/roles.go
+++ b/app/roles.go
@@ -7,6 +7,11 @@ import (
 // Map each node to its metadata. If the node is offline, map to nil.
 type clusterState map[client.NodeInfo]*client.NodeMetadata
 
+// Size returns the number of nodes il the cluster.
+func (c clusterState) Size() int {
+	return len(c)
+}
+
 // Count returns the number of online or offline nodes with the given role.
 func (c clusterState) Count(role client.NodeRole, online bool) int {
 	return len(c.List(role, online))
@@ -23,4 +28,188 @@ func (c clusterState) List(role client.NodeRole, online bool) []client.NodeInfo 
 	return nodes
 }
 
+// Get returns information about the node with the given ID, or nil if no node
+// matches.
+func (c clusterState) Get(id uint64) *client.NodeInfo {
+	for node := range c {
+		if node.ID == id {
+			return &node
+		}
+	}
+	return nil
+}
+
 const minVoters = 3
+
+type rolesAdjustmentAlgorithm struct {
+	voters   int // Target number of voters, 3 by default.
+	standbys int // Target number of stand-bys, 3 by default.
+}
+
+// Decide if a node should change its own role at startup.
+func (a *rolesAdjustmentAlgorithm) Startup(id uint64, cluster clusterState) client.NodeRole {
+	// If the cluster is still too small, do nothing.
+	if cluster.Size() < minVoters {
+		return -1
+	}
+
+	node := cluster.Get(id)
+
+	// If we are not in the cluster, it means we were removed, just do nothing.
+	if node == nil {
+		return -1
+	}
+
+	// If we already have the Voter or StandBy role, there's nothing to do.
+	if node.Role == client.Voter || node.Role == client.StandBy {
+		return -1
+	}
+
+	onlineVoters := cluster.List(client.Voter, true)
+	onlineStandbys := cluster.List(client.StandBy, true)
+
+	// If we have already the desired number of online voters and
+	// stand-bys, there's nothing to do.
+	if len(onlineVoters) >= a.voters && len(onlineStandbys) >= a.standbys {
+		return -1
+	}
+
+	// Figure if we need to become stand-by or voter.
+	role := client.StandBy
+	if len(onlineVoters) < a.voters {
+		role = client.Voter
+	}
+
+	return role
+}
+
+// Decide if a node should try to handover its current role to another
+// node. Return the role that should be handed over and list of candidates that
+// should receive it, in order of preference.
+func (a *rolesAdjustmentAlgorithm) Handover(id uint64, cluster clusterState) (client.NodeRole, []client.NodeInfo) {
+	node := cluster.Get(id)
+
+	// If we are not in the cluster, it means we were removed, just do nothing.
+	if node == nil {
+		return -1, nil
+	}
+
+	// If we aren't a voter or a stand-by, there's nothing to do.
+	if node.Role != client.Voter && node.Role != client.StandBy {
+		return -1, nil
+	}
+
+	// Online spare nodes are always candidates.
+	candidates := cluster.List(client.Spare, true)
+
+	// Stand-by nodes are candidates if we need to transfer voting
+	// rights, and they are preferred over spares.
+	if node.Role == client.Voter {
+		candidates = append(cluster.List(client.StandBy, true), candidates...)
+	}
+
+	if len(candidates) == 0 {
+		// No online node available to be promoted.
+		return -1, nil
+	}
+
+	return node.Role, candidates
+}
+
+// Decide if there should be changes in the current roles. Return the role that
+// should be assigned and a list of candidates that should assume it, in order
+// of preference.
+func (a *rolesAdjustmentAlgorithm) Adjust(leader uint64, cluster clusterState) (client.NodeRole, []client.NodeInfo) {
+	if cluster.Size() == 1 {
+		return -1, nil
+	}
+
+	// If the cluster is too small, make sure we have just one voter (us).
+	if cluster.Size() < minVoters {
+		for node := range cluster {
+			if node.ID == leader || node.Role != client.Voter {
+				continue
+			}
+			return client.Spare, []client.NodeInfo{node}
+		}
+		return -1, nil
+	}
+
+	onlineVoters := cluster.List(client.Voter, true)
+	onlineStandbys := cluster.List(client.StandBy, true)
+	offlineVoters := cluster.List(client.Voter, false)
+	offlineStandbys := cluster.List(client.StandBy, false)
+
+	// If we have exactly the desired number of voters and stand-bys, and they are all
+	// online, we're good.
+	if len(offlineVoters) == 0 && len(onlineVoters) == a.voters && len(offlineStandbys) == 0 && len(onlineStandbys) == a.standbys {
+		return -1, nil
+	}
+
+	// If we have less online voters than desired, let's try to promote
+	// some other node.
+	if n := len(onlineVoters); n < a.voters {
+		candidates := cluster.List(client.StandBy, true)
+		candidates = append(candidates, cluster.List(client.Spare, true)...)
+
+		if len(candidates) == 0 {
+			return -1, nil
+		}
+
+		return client.Voter, candidates
+	}
+
+	// If we have more online voters than desired, let's demote one of
+	// them.
+	if n := len(onlineVoters); n > a.voters {
+		nodes := []client.NodeInfo{}
+		for _, node := range onlineVoters {
+			// Don't demote the leader.
+			if node.ID == leader {
+				continue
+			}
+			nodes = append(nodes, node)
+		}
+
+		return client.Spare, nodes
+	}
+
+	// If we have offline voters, let's demote one of them.
+	if n := len(offlineVoters); n > 0 {
+		return client.Spare, offlineVoters
+	}
+
+	// If we have less online stand-bys than desired, let's try to promote
+	// some other node.
+	if n := len(onlineStandbys); n < a.standbys {
+		candidates := cluster.List(client.Spare, true)
+
+		if len(candidates) == 0 {
+			return -1, nil
+		}
+
+		return client.StandBy, candidates
+	}
+
+	// If we have more online stand-bys than desired, let's demote one of
+	// them.
+	if n := len(onlineStandbys); n > a.standbys {
+		nodes := []client.NodeInfo{}
+		for _, node := range onlineStandbys {
+			// Don't demote the leader.
+			if node.ID == leader {
+				continue
+			}
+			nodes = append(nodes, node)
+		}
+
+		return client.Spare, nodes
+	}
+
+	// If we have offline stand-bys, let's demote one of them.
+	if n := len(offlineStandbys); n > 0 {
+		return client.Spare, offlineStandbys
+	}
+
+	return -1, nil
+}

--- a/app/roles.go
+++ b/app/roles.go
@@ -237,6 +237,9 @@ func (a *rolesAdjustmentAlgorithm) Adjust(leader uint64, cluster clusterState) (
 			return -1, nil
 		}
 
+		domains := cluster.FailureDomains(onlineStandbys)
+		cluster.SortCandidates(candidates, domains)
+
 		return client.StandBy, candidates
 	}
 

--- a/app/roles.go
+++ b/app/roles.go
@@ -1,0 +1,26 @@
+package app
+
+import (
+	"github.com/canonical/go-dqlite/client"
+)
+
+// Map each node to its metadata. If the node is offline, map to nil.
+type clusterState map[client.NodeInfo]*client.NodeMetadata
+
+// Count returns the number of online or offline nodes with the given role.
+func (c clusterState) Count(role client.NodeRole, online bool) int {
+	return len(c.List(role, online))
+}
+
+// List returns the online or offline nodes with the given role.
+func (c clusterState) List(role client.NodeRole, online bool) []client.NodeInfo {
+	nodes := []client.NodeInfo{}
+	for node, metadata := range c {
+		if node.Role == role && metadata != nil == online {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes
+}
+
+const minVoters = 3

--- a/app/roles.go
+++ b/app/roles.go
@@ -80,7 +80,7 @@ func (c clusterState) SortCandidates(candidates []client.NodeInfo, domains map[u
 			return false
 		}
 
-		return false
+		return metadata1.Weight < metadata2.Weight
 	}
 
 	sort.Slice(candidates, less)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -130,6 +130,32 @@ func TestClient_Transfer(t *testing.T) {
 
 }
 
+func TestClient_Describe(t *testing.T) {
+	node, cleanup := newNode(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	cli, err := client.New(ctx, node.BindAddress())
+	require.NoError(t, err)
+	defer cli.Close()
+
+	metadata, err := cli.Describe(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(0), metadata.FailureDomain)
+	assert.Equal(t, uint64(0), metadata.Weight)
+
+	require.NoError(t, cli.Weight(context.Background(), 123))
+
+	metadata, err = cli.Describe(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(0), metadata.FailureDomain)
+	assert.Equal(t, uint64(123), metadata.Weight)
+}
+
 func newNode(t *testing.T) (*dqlite.Node, func()) {
 	t.Helper()
 	dir, dirCleanup := newDir(t)

--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -15,6 +15,7 @@ package bindings
 #define EMIT_BUF_LEN 1024
 
 typedef unsigned long long nanoseconds_t;
+typedef unsigned long long failure_domain_t;
 
 // Duplicate a file descriptor and prevent it from being cloned into child processes.
 static int dupCloexec(int oldfd) {
@@ -148,6 +149,15 @@ func (s *Node) SetNetworkLatency(nanoseconds uint64) error {
 	cnanoseconds := C.nanoseconds_t(nanoseconds)
 	if rc := C.dqlite_node_set_network_latency(server, cnanoseconds); rc != 0 {
 		return fmt.Errorf("failed to set network latency")
+	}
+	return nil
+}
+
+func (s *Node) SetFailureDomain(code uint64) error {
+	server := (*C.dqlite_node)(unsafe.Pointer(s))
+	ccode := C.failure_domain_t(code)
+	if rc := C.dqlite_node_set_failure_domain(server, ccode); rc != 0 {
+		return fmt.Errorf("set failure domain: %d", rc)
 	}
 	return nil
 }

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -54,6 +54,13 @@ const (
 	RequestDump      = 15
 	RequestCluster   = 16
 	RequestTransfer  = 17
+	RequestDescribe  = 18
+	RequestWeight    = 19
+)
+
+// Formats
+const (
+	RequestDescribeFormatV0 = 0
 )
 
 // Response types.
@@ -69,6 +76,7 @@ const (
 	ResponseRows       = 7
 	ResponseEmpty      = 8
 	ResponseFiles      = 9
+	ResponseMetadata   = 10
 )
 
 // Human-readable description of a request type.
@@ -109,6 +117,8 @@ func requestDesc(code uint8) string {
 		return "cluster"
 	case RequestTransfer:
 		return "transfer"
+	case RequestDescribe:
+		return "describe"
 	}
 	return "unknown"
 }
@@ -136,6 +146,8 @@ func responseDesc(code uint8) string {
 		return "empty"
 	case ResponseFiles:
 		return "files"
+	case ResponseMetadata:
+		return "metadata"
 	}
 	return "unknown"
 }

--- a/internal/protocol/request.go
+++ b/internal/protocol/request.go
@@ -154,3 +154,19 @@ func EncodeTransfer(request *Message, id uint64) {
 
 	request.putHeader(RequestTransfer)
 }
+
+// EncodeDescribe encodes a Describe request.
+func EncodeDescribe(request *Message, format uint64) {
+	request.reset()
+	request.putUint64(format)
+
+	request.putHeader(RequestDescribe)
+}
+
+// EncodeWeight encodes a Weight request.
+func EncodeWeight(request *Message, weight uint64) {
+	request.reset()
+	request.putUint64(weight)
+
+	request.putHeader(RequestWeight)
+}

--- a/internal/protocol/response.go
+++ b/internal/protocol/response.go
@@ -253,3 +253,26 @@ func DecodeFiles(response *Message) (files Files, err error) {
 
 	return
 }
+
+// DecodeMetadata decodes a Metadata response.
+func DecodeMetadata(response *Message) (failureDomain uint64, weight uint64, err error) {
+	mtype, _ := response.getHeader()
+
+	if mtype == ResponseFailure {
+		e := ErrRequest{}
+		e.Code = response.getUint64()
+		e.Description = response.getString()
+                err = e
+                return
+	}
+
+	if mtype != ResponseMetadata {
+		err = fmt.Errorf("decode %s: unexpected type %d", responseDesc(ResponseMetadata), mtype)
+                return
+	}
+
+	failureDomain = response.getUint64()
+	weight = response.getUint64()
+
+	return
+}

--- a/internal/protocol/schema.go
+++ b/internal/protocol/schema.go
@@ -18,17 +18,20 @@ package protocol
 //go:generate ./schema.sh --request Remove    id:uint64
 //go:generate ./schema.sh --request Dump      name:string
 //go:generate ./schema.sh --request Cluster   format:uint64
-//go:generate ./schema.sh --request Transfer   id:uint64
+//go:generate ./schema.sh --request Transfer  id:uint64
+//go:generate ./schema.sh --request Describe  format:uint64
+//go:generate ./schema.sh --request Weight    weight:uint64
 
 //go:generate ./schema.sh --response init
 //go:generate ./schema.sh --response Failure  code:uint64 message:string
 //go:generate ./schema.sh --response Welcome  heartbeatTimeout:uint64
 //go:generate ./schema.sh --response NodeLegacy  address:string
-//go:generate ./schema.sh --response Node   id:uint64 address:string
-//go:generate ./schema.sh --response Nodes  servers:Nodes
+//go:generate ./schema.sh --response Node     id:uint64 address:string
+//go:generate ./schema.sh --response Nodes    servers:Nodes
 //go:generate ./schema.sh --response Db       id:uint32 unused:uint32
 //go:generate ./schema.sh --response Stmt     db:uint32 id:uint32 params:uint64
 //go:generate ./schema.sh --response Empty    unused:uint64
 //go:generate ./schema.sh --response Result   result:Result
 //go:generate ./schema.sh --response Rows     rows:Rows
 //go:generate ./schema.sh --response Files    files:Files
+//go:generate ./schema.sh --response Metadata failureDomain:uint64 weight:uint64

--- a/node.go
+++ b/node.go
@@ -45,6 +45,13 @@ func WithNetworkLatency(latency time.Duration) Option {
 	}
 }
 
+// WithFailureDomain sets the code of the failure domain the node belongs to.
+func WithFailureDomain(code uint64) Option {
+	return func(options *options) {
+		options.FailureDomain = code
+	}
+}
+
 // New creates a new Node instance.
 func New(id uint64, address string, dir string, options ...Option) (*Node, error) {
 	o := defaultOptions()
@@ -69,6 +76,11 @@ func New(id uint64, address string, dir string, options ...Option) (*Node, error
 	}
 	if o.NetworkLatency != 0 {
 		if err := server.SetNetworkLatency(o.NetworkLatency); err != nil {
+			return nil, err
+		}
+	}
+	if o.FailureDomain != 0 {
+		if err := server.SetFailureDomain(o.FailureDomain); err != nil {
 			return nil, err
 		}
 	}
@@ -107,6 +119,7 @@ type options struct {
 	DialFunc       client.DialFunc
 	BindAddress    string
 	NetworkLatency uint64
+	FailureDomain  uint64
 }
 
 // Close the server, releasing all resources it created.

--- a/test/roles.sh
+++ b/test/roles.sh
@@ -8,7 +8,7 @@ VERBOSE=${VERBOSE:-0}
 DIR=$(mktemp -d)
 BINARY=$DIR/main
 CLUSTER=127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003,127.0.0.1:9004,127.0.0.1:9005,127.0.0.1:9006
-N=6
+N=7
 
 $GO build -tags libsqlite3 ./cmd/dqlite/
 
@@ -106,7 +106,7 @@ wait_stable() {
     voters=$(./dqlite -s $CLUSTER test .cluster | grep voter | wc -l)
     standbys=$(./dqlite -s $CLUSTER test .cluster | grep stand-by | wc -l)
     spares=$(./dqlite -s $CLUSTER test .cluster | grep spare | wc -l)
-    if [ $voters -eq 3 ] && [ $standbys -eq 2 ] &&  [ $spares -eq 1 ] ; then
+    if [ $voters -eq 3 ] && [ $standbys -eq 3 ] &&  [ $spares -eq 1 ] ; then
         break
     fi
     if [ $i -eq 40 ]; then
@@ -215,7 +215,7 @@ done
 # Stop two nodes at a time gracefully, then check that the cluster is stable.
 for i in $(seq 10); do
     index1=$((1 + RANDOM % $N))
-    index2=$((1 + (index1 + $((RANDOM % 5))) % 6))
+    index2=$((1 + (index1 + $((RANDOM % ($N - 1)))) % $N))
     echo "=> Stop nodes $index1 and $index2"
     kill_node $index1 TERM
     kill_node $index2 TERM
@@ -231,7 +231,7 @@ done
 # Kill two nodes at a time ungracefully, then check that the cluster is stable.
 for i in $(seq 10); do
     index1=$((1 + RANDOM % $N))
-    index2=$((1 + (index1 + $((RANDOM % 5))) % 6))
+    index2=$((1 + (index1 + $((RANDOM % ($N - 1)))) % $N))
     echo "=> Stop nodes $index1 and $index2"
     kill_node $index1 KILL
     kill_node $index2 KILL


### PR DESCRIPTION
Honor user-defined failure domains and weights when picking role handover targets upon node shutdown and replacement targets upon node crash. For now roles of online healthy nodes won't be changed.