### PR TITLE
proxy: close remote

### DIFF
--- a/app/proxy.go
+++ b/app/proxy.go
@@ -79,6 +79,7 @@ func proxy(ctx context.Context, remote net.Conn, local net.Conn, config *tls.Con
 		if err := <-remoteToLocal; err != nil {
 			errs[1] = fmt.Errorf("remote -> local: %v", err)
 		}
+		remote.Close()
 		local.Close()
 
 	}


### PR DESCRIPTION
In all other paths we simply call remote.Close and local.Close but in
this specific part we call CloseRead():
- I would just like to know why we use CloseRead() and not Close()
- The proxy() function is called from

```go
func (a *App) proxy() {
	wg := sync.WaitGroup{}
	ctx, cancel := context.WithCancel(context.Background())
	for {
		client, err := a.listener.Accept()
		if err != nil {
			cancel()
			wg.Wait()
			close(a.proxyCh)
			return
		}
		address := client.RemoteAddr()
		a.debug("new connection from %s", address)
		server, err := net.Dial("unix", a.nodeBindAddress)
		if err != nil {
			a.error("dial local node: %v", err)
			client.Close()
			continue
		}
		wg.Add(1)
		go func() {
			defer wg.Done()
			if err := proxy(ctx, client, server, a.tls.Listen); err != nil {
				a.error("proxy: %v", err)
			}
		}()
	}
}
```

and it seems to me that by not calling close on client (named "remote"
in the proxy function) we might be leaking a connection? Or am I
misunderstandig this. Because it doesn't look like client is closed
properly in this scenario. But maybe I have this all backwards!

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>