### PR TITLE
Build on MacOS with TLS support

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
@@ -198,6 +199,11 @@ func New(dir string, options ...Option) (app *App, err error) {
 	}
 
 	ctx, stop := context.WithCancel(context.Background())
+
+	if runtime.GOOS != "linux" && nodeBindAddress[0] == '@' {
+		// Do not use abstract socket on other platforms and left trim "@"
+		nodeBindAddress = nodeBindAddress[1:]
+	}
 
 	app = &App{
 		id:              info.ID,

--- a/app/proxy.go
+++ b/app/proxy.go
@@ -108,12 +108,12 @@ func setKeepalive(conn *net.TCPConn) error {
 		func(ptr uintptr) {
 			fd := int(ptr)
 			// Number of probes.
-			err = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_KEEPCNT, 3)
+			err = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, _TCP_KEEPCNT, 3)
 			if err != nil {
 				return
 			}
 			// Wait time after an unsuccessful probe.
-			err = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL, 3)
+			err = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, _TCP_KEEPINTVL, 3)
 			if err != nil {
 				return
 			}

--- a/app/proxy_darwin.go
+++ b/app/proxy_darwin.go
@@ -1,0 +1,9 @@
+// +build darwin
+
+package app
+
+// from netinet/tcp.h (OS X 10.9.4)
+const (
+	_TCP_KEEPINTVL = 0x101 /* interval between keepalives */
+	_TCP_KEEPCNT   = 0x102 /* number of keepalives before close */
+)

--- a/app/proxy_linux.go
+++ b/app/proxy_linux.go
@@ -1,0 +1,12 @@
+// +build linux
+
+package app
+
+import (
+	"syscall"
+)
+
+const (
+	_TCP_KEEPINTVL = syscall.TCP_KEEPINTVL /* interval between keepalives */
+	_TCP_KEEPCNT   = syscall.TCP_KEEPCNT   /* number of keepalives before close */
+)


### PR DESCRIPTION
Found a couple of ways to make the logic cross-platform in golang, so seems the patch is actually ready to be a part of the master branch.

Overall the change allows to build demo & deps (with patches to the latest releases) on MacOS and connect to the other nodes (Lin/Mac) using TLS.

To make the TLS work properly on Mac - it uses the regular socket file (abstract one are supported on Linux only) and it's created in the CWD of the process. I think it's the best way to implement, since we can't use `/tmp` or `/var/run` on Windows later.

* MacOS -> MacOS - works well
* Linux -> MacOS - works well
* MacOS -> Linux - joined and looks like the demo is working well

The other patches in series:
* canonical/dqlite#285
* https://github.com/canonical/dqlite/pull/288
* https://github.com/canonical/dqlite/pull/290
* canonical/raft#173