### PR TITLE
app: node: Add raft snapshot parameter options

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,6 +35,8 @@ jobs:
         go get github.com/go-playground/overalls
 
     - name: Build & Test
+      env:
+        CGO_LDFLAGS_ALLOW: "-Wl,-z,now"
       run: |
         go get -t -tags libsqlite3 ./...
         go vet -tags libsqlite3 ./...

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ system, along with its dependencies. You then need to pass the ```-tags```
 argument to the Go tools when building or testing your packages, for example:
 
 ```bash
+export CGO_LDFLAGS_ALLOW="-Wl,-z,now"
 go build -tags libsqlite3
 go test -tags libsqlite3
 ```

--- a/app/app.go
+++ b/app/app.go
@@ -167,6 +167,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 		dqlite.WithDialFunc(nodeDial),
 		dqlite.WithFailureDomain(o.FailureDomain),
 		dqlite.WithNetworkLatency(o.NetworkLatency),
+		dqlite.WithSnapshotParams(o.SnapshotParams),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create node: %w", err)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/canonical/go-dqlite/app"
 	"github.com/canonical/go-dqlite/client"
+	"github.com/canonical/go-dqlite/internal/bindings"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -863,6 +864,17 @@ func TestOpen(t *testing.T) {
 
 	_, err = db.ExecContext(context.Background(), "CREATE TABLE foo(n INT)")
 	assert.NoError(t, err)
+}
+
+// Test some setup options
+func TestOptions(t *testing.T) {
+	options := []app.Option{
+		app.WithNetworkLatency(20 * time.Millisecond),
+		app.WithSnapshotParams(bindings.SnapshotParams{Threshold: 1024, Trailing: 1024}),
+	}
+	app, cleanup := newApp(t, options...)
+	defer cleanup()
+	require.NotNil(t, app)
 }
 
 // Test client connections dropping uncleanly.

--- a/app/options.go
+++ b/app/options.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/canonical/go-dqlite/client"
+	"github.com/canonical/go-dqlite/internal/bindings"
 )
 
 // Option can be used to tweak app parameters.
@@ -141,6 +142,13 @@ func WithNetworkLatency(latency time.Duration) Option {
 	}
 }
 
+// WithSnapshotParams sets the raft snapshot parameters.
+func WithSnapshotParams(params bindings.SnapshotParams) Option {
+	return func(options *options) {
+		options.SnapshotParams = params
+	}
+}
+
 type tlsSetup struct {
 	Listen *tls.Config
 	Dial   *tls.Config
@@ -156,6 +164,7 @@ type options struct {
 	RolesAdjustmentFrequency time.Duration
 	FailureDomain            uint64
 	NetworkLatency           time.Duration
+	SnapshotParams           bindings.SnapshotParams
 }
 
 // Create a options object with sane defaults.

--- a/internal/bindings/build.go
+++ b/internal/bindings/build.go
@@ -1,6 +1,6 @@
 package bindings
 
 /*
-#cgo linux LDFLAGS: -lsqlite3 -lraft -ldqlite
+#cgo linux LDFLAGS: -lsqlite3 -lraft -ldqlite -Wl,-z,now
 */
 import "C"

--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -84,6 +84,11 @@ import (
 
 type Node C.dqlite_node
 
+type SnapshotParams struct {
+	Threshold uint64
+	Trailing  uint64
+}
+
 // Initializes state.
 func init() {
 	// FIXME: ignore SIGPIPE, see https://github.com/joyent/libuv/issues/1254
@@ -150,6 +155,16 @@ func (s *Node) SetNetworkLatency(nanoseconds uint64) error {
 	cnanoseconds := C.nanoseconds_t(nanoseconds)
 	if rc := C.dqlite_node_set_network_latency(server, cnanoseconds); rc != 0 {
 		return fmt.Errorf("failed to set network latency")
+	}
+	return nil
+}
+
+func (s *Node) SetSnapshotParams(params SnapshotParams) error {
+	server := (*C.dqlite_node)(unsafe.Pointer(s))
+	cthreshold := C.unsigned(params.Threshold)
+	ctrailing := C.unsigned(params.Trailing)
+	if rc := C.dqlite_node_set_snapshot_params(server, cthreshold, ctrailing); rc != 0 {
+		return fmt.Errorf("failed to set snapshot params")
 	}
 	return nil
 }

--- a/node.go
+++ b/node.go
@@ -52,6 +52,13 @@ func WithFailureDomain(code uint64) Option {
 	}
 }
 
+// WithSnapshotParams sets the snapshot parameters of the node.
+func WithSnapshotParams(params bindings.SnapshotParams) Option {
+	return func(options *options) {
+		options.SnapshotParams = params
+	}
+}
+
 // New creates a new Node instance.
 func New(id uint64, address string, dir string, options ...Option) (*Node, error) {
 	o := defaultOptions()
@@ -81,6 +88,11 @@ func New(id uint64, address string, dir string, options ...Option) (*Node, error
 	}
 	if o.FailureDomain != 0 {
 		if err := server.SetFailureDomain(o.FailureDomain); err != nil {
+			return nil, err
+		}
+	}
+	if o.SnapshotParams.Threshold != 0 || o.SnapshotParams.Trailing != 0 {
+		if err := server.SetSnapshotParams(o.SnapshotParams); err != nil {
 			return nil, err
 		}
 	}
@@ -120,6 +132,7 @@ type options struct {
 	BindAddress    string
 	NetworkLatency uint64
 	FailureDomain  uint64
+	SnapshotParams bindings.SnapshotParams
 }
 
 // Close the server, releasing all resources it created.


### PR DESCRIPTION
This PR uses the new dqlite API `dqlite_node_set_snapshot_params` available from dqlite `1.8.0`.

I want to update the SONAME of dqlite from `libdqlite.so.0` to `libdqlite.so.1` so that go-dqlite binaries built against a version of dqlite that contain this API fail when ran against an older version of the dqlite library. The problem is, I already released a version of libdqlite with SONAME `libdqlite.so.0` that contains the `dqlite_node_set_snapshot_params` functionality.

I'm not entirely sure if I should:
a) make a new dqlite release `1.9.0` and update the SONAME ? <-- This probably seems most reasonable
b) just update the SONAME on master and not make a release ?
c) ... ?