### PR TITLE
More robust filewriting

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -489,6 +489,11 @@ func (a *App) run(ctx context.Context, frequency time.Duration, join bool) {
 				cli.Close()
 				continue
 			}
+			if len(servers) == 0 {
+				a.warn("server list empty")
+				cli.Close()
+				continue
+			}
 			a.store.Set(ctx, servers)
 
 			// If we are starting up, let's see if we should

--- a/app/files.go
+++ b/app/files.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
+	"github.com/google/renameio"
 )
 
 const (
@@ -40,7 +41,7 @@ func fileExists(dir, file string) (bool, error) {
 func fileWrite(dir, file string, data []byte) error {
 	path := filepath.Join(dir, file)
 
-	if err := ioutil.WriteFile(path, data, 0600); err != nil {
+	if err := renameio.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("write %s: %w", file, err)
 	}
 

--- a/client/store.go
+++ b/client/store.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/ghodss/yaml"
+	"github.com/google/renameio"
 	"github.com/pkg/errors"
 
 	"github.com/canonical/go-dqlite/internal/protocol"
@@ -228,7 +229,7 @@ func (s *YamlNodeStore) Set(ctx context.Context, servers []NodeInfo) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(s.path, data, 0600); err != nil {
+	if err := renameio.WriteFile(s.path, data, 0600); err != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/Rican7/retry v0.1.0
 	github.com/ghodss/yaml v1.0.0
+	github.com/google/renameio v1.0.1
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7
 	github.com/peterh/liner v1.2.1


### PR DESCRIPTION
There are some mentions of corrupted / empty `cluster.yaml` files. This PR should help prevent these cases.

- Atomically replace files when writing by using the [renameio](https://github.com/google/renameio) package.
- Protect against empty server list (if an empty list is ever even possible).

Fixes https://github.com/canonical/go-dqlite/issues/145