### PR TITLE
connect: sort servers by Role

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/renameio v1.0.1 h1:Lh/jXZmvZxb0BBeSY5VKEfidcbcbenKjZFzM/q0fSeU=
+github.com/google/renameio v1.0.1/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWUAweKUpk=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=

--- a/internal/protocol/connector.go
+++ b/internal/protocol/connector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sort"
 	"time"
 
 	"github.com/Rican7/retry"
@@ -119,6 +120,11 @@ func (c *Connector) connectAttemptAll(ctx context.Context, log logging.Func) (*P
 	if err != nil {
 		return nil, errors.Wrap(err, "get servers")
 	}
+
+	// Sort servers by Role, from low to high.
+	sort.Slice(servers, func(i, j int) bool {
+		return servers[i].Role < servers[j].Role
+	})
 
 	// Make an attempt for each address until we find the leader.
 	for _, server := range servers {


### PR DESCRIPTION
Quick win to check voters first when contacting servers to find a leader.