### PR TITLE
shell: Speedup row printing

### DIFF
--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -269,7 +269,7 @@ func (s *Shell) processSelect(ctx context.Context, line string) (string, error) 
 	}
 	n := len(columns)
 
-	result := ""
+	var sb strings.Builder
 	for rows.Next() {
 		row := make([]interface{}, n)
 		rowPointers := make([]interface{}, n)
@@ -282,17 +282,14 @@ func (s *Shell) processSelect(ctx context.Context, line string) (string, error) 
 		}
 
 		for i, column := range row {
-			s := fmt.Sprintf("%v", column)
 			if i == 0 {
-				result += s
+				fmt.Fprintf(&sb, "%v", column)
 			} else {
-				result += "|" + s
+				fmt.Fprintf(&sb, "|%v", column)
 			}
-
 		}
-		result += "\n"
+		sb.WriteByte('\n')
 	}
-	result = strings.TrimRight(result, "\n")
 
 	if err := rows.Err(); err != nil {
 		return "", fmt.Errorf("rows: %w", err)
@@ -302,7 +299,7 @@ func (s *Shell) processSelect(ctx context.Context, line string) (string, error) 
 		return "", fmt.Errorf("commit: %w", err)
 	}
 
-	return result, nil
+	return strings.TrimRight(sb.String(), "\n"), nil
 }
 
 func (s *Shell) processExec(ctx context.Context, line string) error {


### PR DESCRIPTION
Looks like the converting the row to a string takes a large amount of time, these changes amount to approx. a 4x speed increase when performing `select * from kine LIMIT 10000;` on a large kine database. Expect the speedup to be similar for other use cases.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>