### PR TITLE
driver: Add additional busy err codes.

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -46,6 +46,8 @@ type Error = protocol.Error
 // Error codes. Values here mostly overlap with native SQLite codes.
 const (
 	ErrBusy                = 5
+	ErrBusyRecovery        = 5 | (1 << 8)
+	ErrBusySnapshot        = 5 | (2 << 8)
 	errIoErr               = 10
 	errIoErrNotLeader      = errIoErr | 40<<8
 	errIoErrLeadershipLost = errIoErr | (41 << 8)


### PR DESCRIPTION
Overlap with SQLITE_BUSY_RECOVERY and SQLITE_BUSY_SNAPSHOT errors that
can occur in WAL-enabled sqlite databases.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>