### PR TITLE
Benchmark

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,3 +52,26 @@ jobs:
       uses: shogo82148/actions-goveralls@v1
       with:
         path-to-profile: overalls.coverprofile
+
+    - name: Benchmark
+      env:
+        CGO_LDFLAGS_ALLOW: "-Wl,-z,now"
+        GO_DQLITE_MULTITHREAD: 1
+      run: |
+        go install -tags libsqlite3 github.com/canonical/go-dqlite/cmd/dqlite-benchmark
+        dqlite-benchmark --db 127.0.0.1:9001 --driver --cluster 127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003 --workload kvreadwrite &
+        masterpid=$!
+        dqlite-benchmark --db 127.0.0.1:9002 --join 127.0.0.1:9001 &
+        dqlite-benchmark --db 127.0.0.1:9003 --join 127.0.0.1:9001 &
+        wait $masterpid
+        echo "Write results:"
+        head -n 5 /tmp/dqlite-benchmark/127.0.0.1:9001/results/0-exec-*
+
+        echo ""
+        echo "Read results:"
+        head -n 5 /tmp/dqlite-benchmark/127.0.0.1:9001/results/0-query-*
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: dqlite-benchmark-${{ matrix.os }}-${{ matrix.go }}
+        path: /tmp/dqlite-benchmark/127.0.0.1:9001/results/*

--- a/.github/workflows/daily-benchmark.yml
+++ b/.github/workflows/daily-benchmark.yml
@@ -1,0 +1,46 @@
+name: Daily benchmark
+on:
+  schedule:
+    - cron: "0 12 * * *"
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.x
+
+    - name: Setup dependencies
+      run: |
+        sudo add-apt-repository ppa:dqlite/master -y
+        sudo apt update
+        sudo apt install -y libsqlite3-dev libuv1-dev liblz4-dev libraft-dev libdqlite-dev
+
+    - name: Build & Benchmark
+      env:
+        CGO_LDFLAGS_ALLOW: "-Wl,-z,now"
+        GO_DQLITE_MULTITHREAD: 1
+      run: |
+        go get -t -tags libsqlite3 ./...
+        go install -tags libsqlite3 github.com/canonical/go-dqlite/cmd/dqlite-benchmark
+        dqlite-benchmark --db 127.0.0.1:9001 --duration 3600 --driver --cluster 127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003 --workload kvreadwrite &
+        masterpid=$!
+        dqlite-benchmark --db 127.0.0.1:9002 --join 127.0.0.1:9001 &
+        dqlite-benchmark --db 127.0.0.1:9003 --join 127.0.0.1:9001 &
+        wait $masterpid
+        echo "Write results:"
+        head -n 5 /tmp/dqlite-benchmark/127.0.0.1:9001/results/0-exec-*
+
+        echo ""
+        echo "Read results:"
+        head -n 5 /tmp/dqlite-benchmark/127.0.0.1:9001/results/0-query-*
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: dqlite-daily-benchmark
+        path: /tmp/dqlite-benchmark/127.0.0.1:9001/results/*

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -1,0 +1,203 @@
+package benchmark
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"time"
+
+	"github.com/canonical/go-dqlite/app"
+	"github.com/canonical/go-dqlite/client"
+)
+
+const (
+	kvSchema = "CREATE TABLE IF NOT EXISTS model (key TEXT, value TEXT, UNIQUE(key))"
+)
+
+type Benchmark struct {
+	app     *app.App
+	db      *sql.DB
+	dir     string
+	options *options
+	workers []*worker
+}
+
+func createWorkers(o *options) []*worker {
+	workers := make([]*worker, o.nWorkers)
+	for i := 0; i < o.nWorkers; i++ {
+		switch o.workload {
+		case kvWrite:
+			workers[i] = newWorker(kvWriter, o)
+		case kvReadWrite:
+			workers[i] = newWorker(kvReaderWriter, o)
+		}
+	}
+	return workers
+}
+
+func New(app *app.App, db *sql.DB, dir string, options ...Option) (bm *Benchmark, err error) {
+	o := defaultOptions()
+	for _, option := range options {
+		option(o)
+	}
+
+	bm = &Benchmark{
+		app:     app,
+		db:      db,
+		dir:     dir,
+		options: o,
+		workers: createWorkers(o),
+	}
+
+	return bm, nil
+}
+
+func (bm *Benchmark) runWorkload(ctx context.Context) {
+	for _, worker := range bm.workers {
+		go worker.run(ctx, bm.db)
+	}
+}
+
+func (bm *Benchmark) kvSetup() error {
+	_, err := bm.db.Exec(kvSchema)
+	return err
+}
+
+func (bm *Benchmark) setup() error {
+	switch bm.options.workload {
+
+	default:
+		return bm.kvSetup()
+	}
+}
+
+func reportName(id int, work work) string {
+	return fmt.Sprintf("%d-%s-%d", id, work, time.Now().Unix())
+}
+
+// Returns a map of filename to filecontent
+func (bm *Benchmark) reportFiles() map[string]string {
+	allReports := make(map[string]string)
+	for i, worker := range bm.workers {
+		reports := worker.report()
+		for w, report := range reports {
+			file := reportName(i, w)
+			allReports[file] = fmt.Sprintf("%s", report)
+		}
+	}
+	return allReports
+}
+
+func (bm *Benchmark) reportResults() error {
+	dir := path.Join(bm.dir, "results")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("Failed to create %v: %v", dir, err)
+	}
+
+	reports := bm.reportFiles()
+	for filename, content := range reports {
+		f, err := os.Create(path.Join(dir, filename))
+		if err != nil {
+			return fmt.Errorf("Failed to create %v in %v: %v", filename, dir, err)
+		}
+		_, err = f.WriteString(content)
+		if err != nil {
+			return fmt.Errorf("Failed to write %v in %v: %v", filename, dir, err)
+		}
+		f.Sync()
+	}
+
+	return nil
+}
+
+func (bm *Benchmark) nodeOnline(node *client.NodeInfo) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	cli, err := client.New(ctx, node.Address)
+	if err != nil {
+		return false
+	}
+	cli.Close()
+	return true
+}
+
+func (bm *Benchmark) allNodesOnline(ctx context.Context, cancel context.CancelFunc) {
+	for {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return
+		}
+
+		cli, err := bm.app.Client(ctx)
+		if err != nil {
+			continue
+		}
+		nodes, err := cli.Cluster(ctx)
+		if err != nil {
+			continue
+		}
+		cli.Close()
+
+		n := 0
+		for _, needed := range bm.options.cluster {
+			for _, present := range nodes {
+				if needed == present.Address && bm.nodeOnline(&present) {
+					n += 1
+				}
+			}
+		}
+		if len(bm.options.cluster) == n {
+			cancel()
+			return
+		}
+	}
+}
+
+func (bm *Benchmark) waitForCluster(ch <-chan os.Signal) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(bm.options.clusterTimeout))
+	defer cancel()
+
+	go bm.allNodesOnline(ctx, cancel)
+
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			return fmt.Errorf("Timed out waiting for cluster: %v", ctx.Err())
+		}
+		return nil
+	case <-ch:
+		return fmt.Errorf("Benchmark stopped. Signal received while waiting for cluster.")
+	}
+
+}
+
+func (bm *Benchmark) Run(ch <-chan os.Signal) error {
+	if err := bm.setup(); err != nil {
+		return err
+	}
+
+	if err := bm.waitForCluster(ch); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), bm.options.duration)
+	defer cancel()
+
+	bm.runWorkload(ctx)
+
+	select {
+	case <-ctx.Done():
+		break
+	case <-ch:
+		cancel()
+		break
+	}
+
+	if err := bm.reportResults(); err != nil {
+		return err
+	}
+	fmt.Printf("Benchmark done. Results available here:\n%s\n", path.Join(bm.dir, "results"))
+	return nil
+}

--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -1,0 +1,125 @@
+package benchmark_test
+
+import (
+	"context"
+	"database/sql"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/canonical/go-dqlite/app"
+	"github.com/canonical/go-dqlite/benchmark"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	addr1 = "127.0.0.1:9011"
+	addr2 = "127.0.0.1:9012"
+	addr3 = "127.0.0.1:9013"
+)
+
+func bmSetup(t *testing.T, addr string, join []string) (string, *app.App, *sql.DB, func()) {
+	t.Helper()
+
+	dir, err := ioutil.TempDir("", "dqlite-app-test-")
+	require.NoError(t, err)
+
+	app, err := app.New(dir, app.WithAddress(addr), app.WithCluster(join))
+	require.NoError(t, err)
+
+	readyCtx, cancel := context.WithTimeout(context.Background(), time.Duration(3)*time.Second)
+	err = app.Ready(readyCtx)
+	require.NoError(t, err)
+
+	db, err := app.Open(context.Background(), "benchmark")
+	require.NoError(t, err)
+
+	cleanups := func() {
+		os.RemoveAll(dir)
+		cancel()
+	}
+	return dir, app, db, cleanups
+}
+
+func bmRun(t *testing.T, bm *benchmark.Benchmark, app *app.App, db *sql.DB) {
+	defer db.Close()
+	defer app.Close()
+	ch := make(chan os.Signal)
+
+	err := bm.Run(ch)
+	require.NoError(t, err)
+}
+
+// Create a Benchmark with default values.
+func TestNew_Default(t *testing.T) {
+	dir, app, db, cleanup := bmSetup(t, addr1, nil)
+	defer cleanup()
+
+	bm, err := benchmark.New(
+		app,
+		db,
+		dir,
+		benchmark.WithCluster([]string{addr1}),
+		benchmark.WithDuration(1))
+	require.NoError(t, err)
+
+	bmRun(t, bm, app, db)
+}
+
+// Create a Benchmark with a kvReadWriteWorkload.
+func TestNew_KvReadWrite(t *testing.T) {
+	dir, app, db, cleanup := bmSetup(t, addr1, nil)
+	defer cleanup()
+
+	bm, err := benchmark.New(
+		app,
+		db,
+		dir,
+		benchmark.WithCluster([]string{addr1}),
+		benchmark.WithDuration(1),
+		benchmark.WithWorkload("KvReadWrite"))
+	require.NoError(t, err)
+
+	bmRun(t, bm, app, db)
+}
+
+// Create a clustered Benchmark.
+func TestNew_ClusteredKvReadWrite(t *testing.T) {
+	dir, app, db, cleanup := bmSetup(t, addr1, nil)
+	_, _, _, cleanup2 := bmSetup(t, addr2, []string{addr1})
+	_, _, _, cleanup3 := bmSetup(t, addr3, []string{addr1})
+	defer cleanup()
+	defer cleanup2()
+	defer cleanup3()
+
+	bm, err := benchmark.New(
+		app,
+		db,
+		dir,
+		benchmark.WithCluster([]string{addr1, addr2, addr3}),
+		benchmark.WithDuration(2))
+	require.NoError(t, err)
+
+	bmRun(t, bm, app, db)
+}
+
+// Create a clustered Benchmark that times out waiting for the cluster to form.
+func TestNew_ClusteredTimeout(t *testing.T) {
+	dir, app, db, cleanup := bmSetup(t, addr1, nil)
+	defer cleanup()
+	defer db.Close()
+	defer app.Close()
+
+	bm, err := benchmark.New(
+		app,
+		db,
+		dir,
+		benchmark.WithCluster([]string{addr1, addr2}),
+		benchmark.WithClusterTimeout(2))
+	require.NoError(t, err)
+
+	ch := make(chan os.Signal)
+	err = bm.Run(ch)
+	require.Errorf(t, err, "Timed out waiting for cluster: context deadline exceeded")
+}

--- a/benchmark/options.go
+++ b/benchmark/options.go
@@ -1,0 +1,98 @@
+package benchmark
+
+import (
+	"strings"
+	"time"
+)
+
+type workload int32
+
+const (
+	kvWrite     workload = iota
+	kvReadWrite workload = iota
+)
+
+type Option func(*options)
+type options struct {
+	cluster        []string
+	clusterTimeout time.Duration
+	workload       workload
+	duration       time.Duration
+	nWorkers       int
+	kvKeySizeB     int
+	kvValueSizeB   int
+}
+
+func parseWorkload(workload string) workload {
+	switch strings.ToLower(workload) {
+	case "kvwrite":
+		return kvWrite
+	case "kvreadwrite":
+		return kvReadWrite
+	default:
+		return kvWrite
+	}
+}
+
+// WithWorkload sets the workload of the benchmark.
+func WithWorkload(workload string) Option {
+	return func(options *options) {
+		options.workload = parseWorkload(workload)
+	}
+}
+
+// WithDuration sets the duration of the benchmark.
+func WithDuration(seconds int) Option {
+	return func(options *options) {
+		options.duration = time.Duration(seconds) * time.Second
+	}
+}
+
+// WithWorkers sets the number of workers of the benchmark.
+func WithWorkers(n int) Option {
+	return func(options *options) {
+		options.nWorkers = n
+	}
+}
+
+// WithKvKeySize sets the size of the KV keys of the benchmark.
+func WithKvKeySize(bytes int) Option {
+	return func(options *options) {
+		options.kvKeySizeB = bytes
+	}
+}
+
+// WithKvValueSize sets the size of the KV values of the benchmark.
+func WithKvValueSize(bytes int) Option {
+	return func(options *options) {
+		options.kvValueSizeB = bytes
+	}
+}
+
+// WithCluster sets the cluster option of the benchmark. A benchmark will only
+// start once the whole cluster is online.
+func WithCluster(cluster []string) Option {
+	return func(options *options) {
+		options.cluster = cluster
+	}
+}
+
+// WithClusterTimeout sets the timeout when waiting for the whole cluster to be
+// online
+func WithClusterTimeout(cTo int) Option {
+	return func(options *options) {
+		options.clusterTimeout = time.Duration(cTo) * time.Second
+	}
+}
+
+func defaultOptions() *options {
+	return &options{
+		cluster:        nil,
+		clusterTimeout: time.Minute,
+		duration:       time.Minute,
+		kvKeySizeB:     32,
+		kvValueSizeB:   1024,
+		nWorkers:       1,
+		workload:       kvWrite,
+	}
+}

--- a/benchmark/tracker.go
+++ b/benchmark/tracker.go
@@ -1,0 +1,122 @@
+package benchmark
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+)
+
+func durToMs(d time.Duration) string {
+	ms := int64(d / time.Millisecond)
+	rest := int64(d % time.Millisecond)
+	return fmt.Sprintf("%d.%06d", ms, rest)
+}
+
+type measurement struct {
+	start    time.Time
+	duration time.Duration
+}
+
+func (m measurement) String() string {
+	return fmt.Sprintf("%v %v", m.start.UnixNano(), durToMs(m.duration))
+}
+
+type measurementErr struct {
+	start time.Time
+	err   error
+}
+
+func (m measurementErr) String() string {
+	return fmt.Sprintf("%v %v", m.start.UnixNano(), m.err)
+}
+
+type tracker struct {
+	measurements map[work][]measurement
+	errors       map[work][]measurementErr
+}
+
+type report struct {
+	n             int
+	nErr          int
+	totalDuration time.Duration
+	avgDuration   time.Duration
+	maxDuration   time.Duration
+	minDuration   time.Duration
+	measurements  []measurement
+	errors        []measurementErr
+}
+
+func (r report) String() string {
+	var msb strings.Builder
+	for _, m := range r.measurements {
+		fmt.Fprintf(&msb, "%s\n", m)
+	}
+
+	var esb strings.Builder
+	for _, e := range r.errors {
+		fmt.Fprintf(&esb, "%s\n", e)
+	}
+
+	return fmt.Sprintf("n %d\n"+
+		"n_err %d\n"+
+		"avg [ms] %s\n"+
+		"max [ms] %s\n"+
+		"min [ms] %s\n"+
+		"measurements [timestamp in ns] [ms]\n%s\n"+
+		"errors\n%s\n",
+		r.n, r.nErr, durToMs(r.avgDuration),
+		durToMs(r.maxDuration), durToMs(r.minDuration),
+		msb.String(), esb.String())
+}
+
+func (t *tracker) measure(start time.Time, work work, err *error) {
+	duration := time.Since(start)
+	if *err == nil {
+		m := measurement{start, duration}
+		t.measurements[work] = append(t.measurements[work], m)
+	} else {
+		e := measurementErr{start, *err}
+		t.errors[work] = append(t.errors[work], e)
+	}
+}
+
+func (t *tracker) report() map[work]report {
+	reports := make(map[work]report)
+	for w := range t.measurements {
+		report := report{
+			n:             len(t.measurements[w]),
+			nErr:          len(t.errors[w]),
+			totalDuration: 0,
+			avgDuration:   0,
+			maxDuration:   0,
+			minDuration:   time.Duration(math.MaxInt64),
+			measurements:  t.measurements[w],
+			errors:        t.errors[w],
+		}
+
+		for _, m := range t.measurements[w] {
+			report.totalDuration += m.duration
+			if m.duration < report.minDuration {
+				report.minDuration = m.duration
+			}
+			if m.duration > report.maxDuration {
+				report.maxDuration = m.duration
+			}
+		}
+
+		if report.n > 0 {
+			report.avgDuration = report.totalDuration / time.Duration(report.n)
+		}
+		reports[w] = report
+	}
+
+	return reports
+}
+
+func newTracker() *tracker {
+	return &tracker{
+		measurements: make(map[work][]measurement),
+		errors:       make(map[work][]measurementErr),
+	}
+}

--- a/benchmark/worker.go
+++ b/benchmark/worker.go
@@ -1,0 +1,151 @@
+package benchmark
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+)
+
+type work int
+type workerType int
+
+func (w work) String() string {
+	switch w {
+	case exec:
+		return "exec"
+	case query:
+		return "query"
+	case none:
+		return "none"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	// The type of query to perform
+	none  work = iota
+	exec  work = iota // a `write`
+	query work = iota // a `read`
+
+	kvWriter       workerType = iota
+	kvReader       workerType = iota
+	kvReaderWriter workerType = iota
+
+	kvReadSql  = "SELECT value FROM model WHERE key = ?"
+	kvWriteSql = "INSERT OR REPLACE INTO model(key, value) VALUES(?, ?)"
+)
+
+// A worker performs the queries to the database and keeps around some state
+// in order to do that. `lastWork` and `lastArgs` refer to the previously
+// executed operation and can be used to determine the next work the worker
+// should perform. `kvKeys` tells the worker which keys it has inserted in the
+// database.
+type worker struct {
+	workerType   workerType
+	lastWork     work
+	lastArgs     []interface{}
+	tracker      *tracker
+	kvKeySizeB   int
+	kvValueSizeB int
+	kvKeys       []string
+}
+
+// Thanks to https://stackoverflow.com/a/22892986
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randSeq(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func (w *worker) randNewKey() string {
+	return randSeq(w.kvKeySizeB)
+}
+
+func (w *worker) randExistingKey() (string, error) {
+	n := len(w.kvKeys)
+	if n == 0 {
+		return "", errors.New("no keys")
+	}
+	return w.kvKeys[rand.Intn(n)], nil
+}
+
+// A mix of random bytes and easily compressable bytes.
+func (w *worker) randValue() string {
+	return strings.Repeat(randSeq(1), w.kvValueSizeB/2) + randSeq(w.kvValueSizeB/2)
+}
+
+// Returns the type of work to execute and a sql statement with arguments
+func (w *worker) getWork() (work, string, []interface{}) {
+	switch w.workerType {
+	case kvWriter:
+		k, v := w.randNewKey(), w.randValue()
+		return exec, kvWriteSql, []interface{}{k, v}
+	case kvReaderWriter:
+		read := rand.Intn(2) == 0
+		if read && len(w.kvKeys) != 0 {
+			k, _ := w.randExistingKey()
+			return query, kvReadSql, []interface{}{k}
+		}
+		k, v := w.randNewKey(), w.randValue()
+		return exec, kvWriteSql, []interface{}{k, v}
+	default:
+		return none, "", []interface{}{}
+	}
+}
+
+// Retrieve a query and execute it against the database
+func (w *worker) doWork(ctx context.Context, db *sql.DB) {
+	var err error
+	var str string
+
+	work, q, args := w.getWork()
+	w.lastWork = work
+	w.lastArgs = args
+
+	switch work {
+	case exec:
+		w.kvKeys = append(w.kvKeys, fmt.Sprintf("%v", (args[0])))
+		defer w.tracker.measure(time.Now(), work, &err)
+		_, err = db.ExecContext(ctx, q, args...)
+		if err != nil {
+			w.kvKeys = w.kvKeys[:len(w.kvKeys)-1]
+		}
+	case query:
+		defer w.tracker.measure(time.Now(), work, &err)
+		err = db.QueryRowContext(ctx, q, args...).Scan(&str)
+	default:
+		return
+	}
+}
+
+func (w *worker) run(ctx context.Context, db *sql.DB) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		w.doWork(ctx, db)
+	}
+}
+
+func (w *worker) report() map[work]report {
+	return w.tracker.report()
+}
+
+func newWorker(workerType workerType, o *options) *worker {
+	return &worker{
+		workerType:   workerType,
+		kvKeySizeB:   o.kvKeySizeB,
+		kvValueSizeB: o.kvValueSizeB,
+		tracker:      newTracker(),
+	}
+}

--- a/cmd/dqlite-benchmark/dqlite-benchmark.go
+++ b/cmd/dqlite-benchmark/dqlite-benchmark.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"time"
+
+	"github.com/canonical/go-dqlite/app"
+	"github.com/canonical/go-dqlite/benchmark"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	defaultClusterTimeout = 120
+	defaultDir            = "/tmp/dqlite-benchmark"
+	defaultDriver         = false
+	defaultDurationS      = 60
+	defaultKvKeySize      = 32
+	defaultKvValueSize    = 1024
+	defaultWorkers        = 1
+	defaultWorkload       = "kvwrite"
+	docString             = "For benchmarking dqlite.\n\n" +
+		"Run a 1 node benchmark:\n" +
+		"dqlite-benchmark -d 127.0.0.1:9001 --driver --cluster 127.0.0.1:9001\n\n" +
+		"Run a multi-node benchmark, the first node will self-elect and become leader,\n" +
+		"the driver flag results in the workload being run from the first, leader node.\n" +
+		"dqlite-benchmark --db 127.0.0.1:9001 --driver --cluster 127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003 &\n" +
+		"dqlite-benchmark --db 127.0.0.1:9002 --join 127.0.0.1:9001 &\n" +
+		"dqlite-benchmark --db 127.0.0.1:9003 --join 127.0.0.1:9001 &\n\n" +
+		"Run a multi-node benchmark, the first node will self-elect and become leader,\n" +
+		"the driver flag results in the workload being run from the third, non-leader node.\n" +
+		"dqlite-benchmark --db 127.0.0.1:9001 &\n" +
+		"dqlite-benchmark --db 127.0.0.1:9002 --join 127.0.0.1:9001 &\n" +
+		"dqlite-benchmark --db 127.0.0.1:9003 --join 127.0.0.1:9001 --driver --cluster 127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003 &\n\n" +
+		"The results can be found on the `driver` node in " + defaultDir + "/results or in the directory provided to the tool.\n" +
+		"Benchmark results are files named `n-q-timestamp` where `n` is the number of the worker,\n" +
+		"`q` is the type of query that was tracked. All results in the file are in milliseconds.\n"
+)
+
+func signalChannel() chan os.Signal {
+	ch := make(chan os.Signal)
+	signal.Notify(ch, unix.SIGPWR)
+	signal.Notify(ch, unix.SIGINT)
+	signal.Notify(ch, unix.SIGQUIT)
+	signal.Notify(ch, unix.SIGTERM)
+	return ch
+}
+
+func main() {
+	var cluster *[]string
+	var clusterTimeout int
+	var db string
+	var dir string
+	var driver bool
+	var duration int
+	var join *[]string
+	var kvKeySize int
+	var kvValueSize int
+	var workers int
+	var workload string
+
+	cmd := &cobra.Command{
+		Use:   "dqlite-benchmark",
+		Short: "For benchmarking dqlite",
+		Long:  docString,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := filepath.Join(dir, db)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				return errors.Wrapf(err, "can't create %s", dir)
+			}
+
+			app, err := app.New(dir, app.WithAddress(db), app.WithCluster(*join))
+			if err != nil {
+				return err
+			}
+
+			readyCtx, cancel := context.WithTimeout(context.Background(), time.Duration(clusterTimeout)*time.Second)
+			defer cancel()
+			if err := app.Ready(readyCtx); err != nil {
+				return errors.Wrap(err, "App not ready in time")
+			}
+
+			ch := signalChannel()
+			if !driver {
+				fmt.Println("Benchmark client ready. Send signal to abort or when done.")
+				select {
+				case <-ch:
+					return nil
+				}
+			}
+
+			if len(*cluster) == 0 {
+				return fmt.Errorf("driver node, `--cluster` flag must be provided")
+			}
+
+			db, err := app.Open(context.Background(), "benchmark")
+			if err != nil {
+				return err
+			}
+			db.SetMaxOpenConns(500)
+			db.SetMaxIdleConns(500)
+
+			bm, err := benchmark.New(
+				app,
+				db,
+				dir,
+				benchmark.WithWorkload(workload),
+				benchmark.WithDuration(duration),
+				benchmark.WithWorkers(workers),
+				benchmark.WithKvKeySize(kvKeySize),
+				benchmark.WithKvValueSize(kvValueSize),
+				benchmark.WithCluster(*cluster),
+				benchmark.WithClusterTimeout(clusterTimeout),
+			)
+			if err != nil {
+				return err
+			}
+
+			if err := bm.Run(ch); err != nil {
+				return err
+			}
+
+			db.Close()
+			app.Close()
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&db, "db", "d", "", "Address used for internal database replication.")
+	join = flags.StringSliceP("join", "j", nil, "Database addresses of existing nodes.")
+	cluster = flags.StringSliceP("cluster", "c", nil, "Database addresses of all nodes taking part in the benchmark.\n"+
+		"The `driver` will wait for all nodes to be online before running the benchmark.")
+	flags.IntVar(&clusterTimeout, "cluster-timeout", defaultClusterTimeout, "How long the benchmark should wait in seconds for the whole cluster to be online.")
+	flags.StringVarP(&dir, "dir", "D", defaultDir, "Data directory.")
+	flags.StringVarP(&workload, "workload", "w", defaultWorkload, "The workload to run: \"kvwrite\" or \"kvreadwrite\".")
+	flags.BoolVar(&driver, "driver", defaultDriver, "Set this flag to run the benchmark from this instance. Must be set on 1 node.")
+	flags.IntVar(&duration, "duration", defaultDurationS, "Run duration in seconds.")
+	flags.IntVar(&workers, "workers", defaultWorkers, "Number of workers executing the workload.")
+	flags.IntVar(&kvKeySize, "key-size", defaultKvKeySize, "Size of the KV keys in bytes.")
+	flags.IntVar(&kvValueSize, "value-size", defaultKvValueSize, "Size of the KV values in bytes.")
+
+	cmd.MarkFlagRequired("db")
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/driver/integration_test.go
+++ b/driver/integration_test.go
@@ -119,7 +119,7 @@ func TestIntegration_QueryBindError(t *testing.T) {
 	defer cleanup()
 	defer db.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 9*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
 	_, err := db.QueryContext(ctx, "SELECT 1", 1)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea
+	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -34,7 +34,6 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -105,10 +104,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -140,7 +137,6 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -178,7 +174,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -247,8 +242,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea h1:+WiDlPBBaO+h9vPNZi8uJ3k4BkKQB7Iow3aqwHVA5hI=
-golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -295,7 +289,6 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
@@ -306,7 +299,6 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Added `dqlite-benchmark` command, here's the `--help` output.

```
For benchmarking dqlite.

Run a 1 node benchmark:
dqlite-benchmark -d 127.0.0.1:9001 --driver --cluster 127.0.0.1:9001

Run a multi-node benchmark, the first node will self-elect and become leader,
the driver flag results in the workload being run from the first, leader node.
dqlite-benchmark --db 127.0.0.1:9001 --driver --cluster 127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003 &
dqlite-benchmark --db 127.0.0.1:9002 --join 127.0.0.1:9001 &
dqlite-benchmark --db 127.0.0.1:9003 --join 127.0.0.1:9001 &

Run a multi-node benchmark, the first node will self-elect and become leader,
the driver flag results in the workload being run from the third, non-leader node.
dqlite-benchmark --db 127.0.0.1:9001 &
dqlite-benchmark --db 127.0.0.1:9002 --join 127.0.0.1:9001 &
dqlite-benchmark --db 127.0.0.1:9003 --join 127.0.0.1:9001 --driver --cluster 127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003 &

The results can be found on the `driver` node in /tmp/dqlite-benchmark/results or in the directory provided to the tool.
Benchmark results are files named `n-q-timestamp` where `n` is the number of the worker,
`q` is the type of query that was tracked. All results in the file are in milliseconds.

Usage:
  dqlite-benchmark [flags]

Flags:
  -c, --cluster driver        Database addresses of all nodes taking part in the benchmark.
                              The driver will wait for all nodes to be online before running the benchmark.
      --cluster-timeout int   How long the benchmark should wait in seconds for the whole cluster to be online. (default 120)
  -d, --db string             Address used for internal database replication.
  -D, --dir string            Data directory. (default "/tmp/dqlite-benchmark")
      --driver                Set this flag to run the benchmark from this instance. Must be set on 1 node.
      --duration int          Run duration in seconds. (default 60)
  -h, --help                  help for dqlite-benchmark
  -j, --join strings          Database addresses of existing nodes.
      --key-size int          Size of the KV keys in bytes. (default 32)
      --value-size int        Size of the KV values in bytes. (default 1024)
      --workers int           Number of workers executing the workload. (default 1)
  -w, --workload string       The workload to run: "kvwrite" or "kvreadwrite". (default "kvwrite")

```

output looks like
```
$ head -n 30 /tmp/dqlite-benchmark/127.0.0.1\:9001/results/0-exec-1632731113 
n 1010425
n_err 0
avg [ms] 0.396477
max [ms] 429.863488
min [ms] 0.087790
measurements [timestamp in ns] [ms]
1632730677520050249 0.236091
1632730677520326450 0.228581
1632730677520581591 0.274461
1632730677520879532 0.370711
1632730677521280533 0.228141
1632730677521531744 0.234931
1632730677521793565 0.312891
1632730677522134206 0.236751
1632730677522400587 0.240801
1632730677522669048 0.339361
1632730677523034609 0.221181
1632730677523278490 0.244211
1632730677523553421 0.335441
1632730677523912202 0.261241
1632730677524204013 0.265561
1632730677524492774 0.353511
1632730677524876635 0.267651
1632730677525175046 0.259781
1632730677525460227 0.349841
1632730677525832788 0.264831
1632730677526127879 0.258901
1632730677526411360 0.367361
1632730677526805631 0.272801
1632730677527101142 0.259461
...
```