### PR TITLE
github: Disable packages on bionic

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -7,7 +7,6 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - bionic
           - focal
           - impish
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Ubuntu 18.04 ships with Go 1.10 which is too old for dqlite.