### PR TITLE
Armhf test fixes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -623,7 +623,7 @@ func (a *App) makeRolesChanges(nodes []client.NodeInfo) RolesChanges {
 		go func(node protocol.NodeInfo) {
 			defer wg.Done()
 			defer sem.Release(1)
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
 
 			cli, err := client.New(ctx, node.Address, a.clientOptions()...)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -537,7 +537,7 @@ func TestRolesAdjustment_ReplaceVoter(t *testing.T) {
 		addr := fmt.Sprintf("127.0.0.1:900%d", i+1)
 		options := []app.Option{
 			app.WithAddress(addr),
-			app.WithRolesAdjustmentFrequency(500 * time.Millisecond),
+			app.WithRolesAdjustmentFrequency(2 * time.Second),
 		}
 		if i > 0 {
 			options = append(options, app.WithCluster([]string{"127.0.0.1:9001"}))
@@ -558,7 +558,7 @@ func TestRolesAdjustment_ReplaceVoter(t *testing.T) {
 	// A voter goes offline.
 	cleanups[2]()
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(8 * time.Second)
 
 	cli, err := apps[0].Leader(context.Background())
 	require.NoError(t, err)
@@ -585,7 +585,7 @@ func TestRolesAdjustment_ReplaceVoterHonorFailureDomain(t *testing.T) {
 		addr := fmt.Sprintf("127.0.0.1:900%d", i+1)
 		options := []app.Option{
 			app.WithAddress(addr),
-			app.WithRolesAdjustmentFrequency(500 * time.Millisecond),
+			app.WithRolesAdjustmentFrequency(4 * time.Second),
 			app.WithFailureDomain(uint64(i % 3)),
 		}
 		if i > 0 {
@@ -609,7 +609,7 @@ func TestRolesAdjustment_ReplaceVoterHonorFailureDomain(t *testing.T) {
 	// A voter in failure domain 2 goes offline.
 	cleanups[2]()
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(12 * time.Second)
 
 	cli, err := apps[0].Leader(context.Background())
 	require.NoError(t, err)
@@ -638,7 +638,7 @@ func TestRolesAdjustment_ReplaceVoterHonorWeight(t *testing.T) {
 		addr := fmt.Sprintf("127.0.0.1:900%d", i+1)
 		options := []app.Option{
 			app.WithAddress(addr),
-			app.WithRolesAdjustmentFrequency(500 * time.Millisecond),
+			app.WithRolesAdjustmentFrequency(4 * time.Second),
 		}
 		if i > 0 {
 			options = append(options, app.WithCluster([]string{"127.0.0.1:9001"}))
@@ -676,7 +676,7 @@ func TestRolesAdjustment_ReplaceVoterHonorWeight(t *testing.T) {
 	require.NoError(t, cli.Weight(context.Background(), uint64(10)))
 	defer cli.Close()
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(12 * time.Second)
 
 	cli, err = apps[0].Leader(context.Background())
 	require.NoError(t, err)
@@ -705,7 +705,7 @@ func TestRolesAdjustment_CantReplaceVoter(t *testing.T) {
 		addr := fmt.Sprintf("127.0.0.1:900%d", i+1)
 		options := []app.Option{
 			app.WithAddress(addr),
-			app.WithRolesAdjustmentFrequency(500 * time.Millisecond),
+			app.WithRolesAdjustmentFrequency(4 * time.Second),
 		}
 		if i > 0 {
 			options = append(options, app.WithCluster([]string{"127.0.0.1:9001"}))
@@ -726,7 +726,7 @@ func TestRolesAdjustment_CantReplaceVoter(t *testing.T) {
 	cleanups[3]()
 	cleanups[2]()
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(12 * time.Second)
 
 	cli, err := apps[0].Leader(context.Background())
 	require.NoError(t, err)
@@ -751,7 +751,7 @@ func TestRolesAdjustment_ReplaceStandBy(t *testing.T) {
 		addr := fmt.Sprintf("127.0.0.1:900%d", i+1)
 		options := []app.Option{
 			app.WithAddress(addr),
-			app.WithRolesAdjustmentFrequency(500 * time.Millisecond),
+			app.WithRolesAdjustmentFrequency(5 * time.Second),
 		}
 		if i > 0 {
 			options = append(options, app.WithCluster([]string{"127.0.0.1:9001"}))
@@ -775,7 +775,7 @@ func TestRolesAdjustment_ReplaceStandBy(t *testing.T) {
 	// A stand-by goes offline.
 	cleanups[4]()
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(15 * time.Second)
 
 	cli, err := apps[0].Leader(context.Background())
 	require.NoError(t, err)
@@ -805,7 +805,7 @@ func TestRolesAdjustment_ReplaceStandByHonorFailureDomains(t *testing.T) {
 		addr := fmt.Sprintf("127.0.0.1:900%d", i+1)
 		options := []app.Option{
 			app.WithAddress(addr),
-			app.WithRolesAdjustmentFrequency(500 * time.Millisecond),
+			app.WithRolesAdjustmentFrequency(5 * time.Second),
 			app.WithFailureDomain(uint64(i % 3)),
 		}
 		if i > 0 {
@@ -832,7 +832,7 @@ func TestRolesAdjustment_ReplaceStandByHonorFailureDomains(t *testing.T) {
 	// A stand-by from failure domain 1 goes offline.
 	cleanups[4]()
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(15 * time.Second)
 
 	cli, err := apps[0].Leader(context.Background())
 	require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 )

--- a/go.sum
+++ b/go.sum
@@ -355,6 +355,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/protocol/message_internal_test.go
+++ b/internal/protocol/message_internal_test.go
@@ -14,7 +14,7 @@ func TestMessage_StaticBytesAlignment(t *testing.T) {
 	message := Message{}
 	message.Init(4096)
 	pointer := uintptr(unsafe.Pointer(&message.body.Bytes))
-	assert.Equal(t, pointer%messageWordSize, uintptr(0))
+	assert.Equal(t, uintptr(0), pointer%messageWordSize)
 }
 
 func TestMessage_putBlob(t *testing.T) {

--- a/internal/protocol/message_internal_test.go
+++ b/internal/protocol/message_internal_test.go
@@ -13,7 +13,7 @@ import (
 func TestMessage_StaticBytesAlignment(t *testing.T) {
 	message := Message{}
 	message.Init(4096)
-	pointer := uintptr(unsafe.Pointer(&message.body.Bytes))
+	pointer := uintptr(unsafe.Pointer(&message.body.Bytes[0]))
 	assert.Equal(t, uintptr(0), pointer%messageWordSize)
 }
 


### PR DESCRIPTION
- Fix test checking alignment of slice instead of the data contained in the slice.
- Parallelize `makeRolesChanges`. This function probes all nodes for connectivity, performing the probe sequentially could take a while in some cases.
- Increase timeout on the RolesAdjustment tests. The changes in timing might look a bit extreme, but in real-life the `RoleAdjustmentFrequency` is set to 30 seconds, which is still a lot less frequent than in the tests.
Lowering the `RoleAdjustmentFrequency` lowers the load on the testmachines (especially an underpowered armhf machine), they have to setup a lot less TLS connections. I blame TLS for the flakyness of the tests on the armhf machine because when it is turned off, the tests run a lot faster, don't max out the CPU and are not flaky anymore.

An alternative would be to turn off TLS for those tests. 