### PR TITLE
internal/protocol/message: Don't convert retrieved datetimes to local timezone

### DIFF
--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -547,7 +547,7 @@ func (r *Rows) Next(dest []driver.Value) error {
 			if err != nil {
 				return err
 			}
-			t = t.In(time.Local)
+
 			dest[i] = t
 		case Boolean:
 			dest[i] = r.message.getInt64() != 0


### PR DESCRIPTION
This aligns to the default behaviour of go-sqlite3 (without the `_loc` DSN argument) that does not convert by default.

Otherwise this causes some undesirable behaviour when writing back a time.Time value retrieved from the database, as it will cause the value in the database to be mutated incorrectly to the local time, unless it is manually converted back to UTC.

Fixes https://github.com/lxc/lxd/issues/9747

Signed-off-by: Thomas Parrott <tomp@tomp.uk>