### PR TITLE
Add WithExternalConn to app.App

### DIFF
--- a/app/options.go
+++ b/app/options.go
@@ -45,6 +45,19 @@ func WithCluster(cluster []string) Option {
 	}
 }
 
+// WithExternalConn enables passing an external dial function that will be used
+// whenever dqlite needs to make an outside connection.
+//
+// Also takes a net.Conn channel that should be received when the external connection has been accepted.
+func WithExternalConn(dialFunc client.DialFunc, acceptCh chan net.Conn) Option {
+	return func(options *options) {
+		options.Conn = &connSetup{
+			dialFunc: dialFunc,
+			acceptCh: acceptCh,
+		}
+	}
+}
+
 // WithTLS enables TLS encryption of network traffic.
 //
 // The "listen" parameter must hold the TLS configuration to use when accepting
@@ -155,11 +168,17 @@ type tlsSetup struct {
 	Dial   *tls.Config
 }
 
+type connSetup struct {
+	dialFunc client.DialFunc
+	acceptCh chan net.Conn
+}
+
 type options struct {
 	Address                  string
 	Cluster                  []string
 	Log                      client.LogFunc
 	TLS                      *tlsSetup
+	Conn                     *connSetup
 	Voters                   int
 	StandBys                 int
 	RolesAdjustmentFrequency time.Duration


### PR DESCRIPTION
This takes a bunch of the logic from the dqlite proxies in lxd's `Gateway` and applies them to `app.App` via a `WithExternalConn` option.

`WithExternalConn` takes a `client.DialFunc` and an `acceptCh` which will be used for back and forth handling of the external connection. 

I modified the TLS keep alive options a little to look more like how we handle them in LXD [here.](https://github.com/lxc/lxd/blob/ddc19d45afd6344fa21d2db0a6e0fbf31c50a36c/lxd/util/net.go#L333-L376)
