### PR TITLE
Don't use background context for c bindings.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -37,6 +37,7 @@ type App struct {
 	driver          *driver.Driver
 	driverName      string
 	log             client.LogFunc
+	ctx             context.Context
 	stop            context.CancelFunc // Signal App.run() to stop.
 	proxyCh         chan struct{}      // Waits for App.proxy() to return.
 	runCh           chan struct{}      // Waits for App.run() to return.
@@ -159,9 +160,10 @@ func New(dir string, options ...Option) (app *App, err error) {
 	}
 
 	// Start the local dqlite engine.
+	ctx, stop := context.WithCancel(context.Background())
 	var nodeDial client.DialFunc
 	if o.Conn != nil {
-		nodeDial = extDialFuncWithProxy(o.Conn.dialFunc)
+		nodeDial = extDialFuncWithProxy(ctx, o.Conn.dialFunc)
 	} else if o.TLS != nil {
 		nodeBindAddress = fmt.Sprintf("@dqlite-%d", info.ID)
 
@@ -173,7 +175,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 			nodeBindAddress = fmt.Sprintf("@snap.%s.dqlite-%d", snapInstanceName, info.ID)
 		}
 
-		nodeDial = makeNodeDialFunc(o.TLS.Dial)
+		nodeDial = makeNodeDialFunc(ctx, o.TLS.Dial)
 	} else {
 		nodeBindAddress = info.Address
 		nodeDial = client.DefaultDialFunc
@@ -187,9 +189,11 @@ func New(dir string, options ...Option) (app *App, err error) {
 		dqlite.WithSnapshotParams(o.SnapshotParams),
 	)
 	if err != nil {
+		stop()
 		return nil, fmt.Errorf("create node: %w", err)
 	}
 	if err := node.Start(); err != nil {
+		stop()
 		return nil, fmt.Errorf("start node: %w", err)
 	}
 	cleanups = append(cleanups, func() { node.Close() })
@@ -204,6 +208,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 
 	driver, err := driver.New(store, driver.WithDialFunc(driverDial), driver.WithLogFunc(o.Log))
 	if err != nil {
+		stop()
 		return nil, fmt.Errorf("create driver: %w", err)
 	}
 	driverIndex++
@@ -211,14 +216,14 @@ func New(dir string, options ...Option) (app *App, err error) {
 	sql.Register(driverName, driver)
 
 	if o.Voters < 3 || o.Voters%2 == 0 {
+		stop()
 		return nil, fmt.Errorf("invalid voters %d: must be an odd number greater than 1", o.Voters)
 	}
 
 	if o.StandBys%2 == 0 {
+		stop()
 		return nil, fmt.Errorf("invalid stand-bys %d: must be an odd number", o.StandBys)
 	}
-
-	ctx, stop := context.WithCancel(context.Background())
 
 	if runtime.GOOS != "linux" && nodeBindAddress[0] == '@' {
 		// Do not use abstract socket on other platforms and left trim "@"
@@ -237,6 +242,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 		driverName:      driverName,
 		log:             o.Log,
 		tls:             o.TLS,
+		ctx:             ctx,
 		stop:            stop,
 		runCh:           make(chan struct{}, 0),
 		readyCh:         make(chan struct{}, 0),
@@ -270,7 +276,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 					panic(fmt.Errorf("Failed to connect to bind address %q: %w", nodeBindAddress, err))
 				}
 
-				go proxy(ctx, remote, local, nil)
+				go proxy(app.ctx, remote, local, nil)
 			}
 		}()
 	}
@@ -451,7 +457,7 @@ func (a *App) Client(ctx context.Context) (*client.Client, error) {
 // Proxy incoming TLS connections.
 func (a *App) proxy() {
 	wg := sync.WaitGroup{}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(a.ctx)
 	for {
 		client, err := a.listener.Accept()
 		if err != nil {

--- a/internal/bindings/server_test.go
+++ b/internal/bindings/server_test.go
@@ -1,6 +1,7 @@
 package bindings_test
 
 import (
+	"context"
 	"encoding/binary"
 	"io/ioutil"
 	"net"
@@ -24,7 +25,7 @@ func TestNode_Start(t *testing.T) {
 	dir, cleanup := newDir(t)
 	defer cleanup()
 
-	server, err := bindings.NewNode(1, "1", dir)
+	server, err := bindings.NewNode(context.Background(), 1, "1", dir)
 	require.NoError(t, err)
 	defer server.Close()
 
@@ -48,7 +49,7 @@ func TestNode_Restart(t *testing.T) {
 	dir, cleanup := newDir(t)
 	defer cleanup()
 
-	server, err := bindings.NewNode(1, "1", dir)
+	server, err := bindings.NewNode(context.Background(), 1, "1", dir)
 	require.NoError(t, err)
 
 	require.NoError(t, server.SetBindAddress("@abc"))
@@ -57,7 +58,7 @@ func TestNode_Restart(t *testing.T) {
 	require.NoError(t, server.Stop())
 	server.Close()
 
-	server, err = bindings.NewNode(1, "1", dir)
+	server, err = bindings.NewNode(context.Background(), 1, "1", dir)
 	require.NoError(t, err)
 
 	require.NoError(t, server.SetBindAddress("@abc"))
@@ -71,7 +72,7 @@ func TestNode_Start_Inet(t *testing.T) {
 	dir, cleanup := newDir(t)
 	defer cleanup()
 
-	server, err := bindings.NewNode(1, "1", dir)
+	server, err := bindings.NewNode(context.Background(), 1, "1", dir)
 	require.NoError(t, err)
 	defer server.Close()
 
@@ -151,7 +152,7 @@ func newNode(t *testing.T) (*bindings.Node, func()) {
 
 	dir, dirCleanup := newDir(t)
 
-	server, err := bindings.NewNode(1, "1", dir)
+	server, err := bindings.NewNode(context.Background(), 1, "1", dir)
 	require.NoError(t, err)
 
 	err = server.SetBindAddress("@test")

--- a/internal/protocol/connector_test.go
+++ b/internal/protocol/connector_test.go
@@ -332,7 +332,7 @@ func newNode(t *testing.T, index int) (string, func()) {
 
 	address := fmt.Sprintf("@test-%d", index)
 
-	server, err := bindings.NewNode(id, address, dir)
+	server, err := bindings.NewNode(context.Background(), id, address, dir)
 	require.NoError(t, err)
 
 	err = server.SetBindAddress(address)

--- a/node.go
+++ b/node.go
@@ -70,7 +70,7 @@ func New(id uint64, address string, dir string, options ...Option) (*Node, error
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	server, err := bindings.NewNode(id, address, dir)
+	server, err := bindings.NewNode(ctx, id, address, dir)
 	if err != nil {
 		cancel()
 		return nil, err
@@ -176,7 +176,7 @@ func GenerateID(address string) uint64 {
 // It forces appending a new configuration to the raft log stored in the given
 // directory, effectively replacing the current configuration.
 func ReconfigureMembership(dir string, cluster []NodeInfo) error {
-	server, err := bindings.NewNode(1, "1", dir)
+	server, err := bindings.NewNode(context.Background(), 1, "1", dir)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func ReconfigureMembership(dir string, cluster []NodeInfo) error {
 }
 
 func ReconfigureMembershipExt(dir string, cluster []NodeInfo) error {
-	server, err := bindings.NewNode(1, "1", dir)
+	server, err := bindings.NewNode(context.Background(), 1, "1", dir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds a context to the dqlite server `Node` struct which starts on creation and is cancelled on close. This context is passed to the C bindings and stored in a `contextRegistry`, from which the `dialCtx` is derived.

As well, The `App` context is passed to the proxied dial functions for external connections and TLS.