### PR TITLE
go.mod: Update Rican7/retry to v0.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/canonical/go-dqlite
 go 1.14
 
 require (
-	github.com/Rican7/retry v0.1.0
+	github.com/Rican7/retry v0.3.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/renameio v1.0.1
 	github.com/mattn/go-runewidth v0.0.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Rican7/retry v0.1.0 h1:FqK94z34ly8Baa6K+G8Mmza9rYWTKOJk+yckIBB5qVk=
 github.com/Rican7/retry v0.1.0/go.mod h1:FgOROf8P5bebcC1DS0PdOQiqGUridaZvikzUmkFW6gg=
+github.com/Rican7/retry v0.3.0 h1:ixNrbGAPoTSjXhcXOKT/X6bj3wexR4DPqWVrdkl+9K0=
+github.com/Rican7/retry v0.3.0/go.mod h1:CxSDrhAyXmTMeEuRAnArMu1FHu48vtfjLREWqVl7Vw0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/internal/protocol/connector.go
+++ b/internal/protocol/connector.go
@@ -301,11 +301,12 @@ func (c *Connector) connectAttemptOne(ctx context.Context, address string, versi
 // Return a retry strategy with exponential backoff, capped at the given amount
 // of time and possibly with a maximum number of retries.
 func makeRetryStrategies(factor, cap time.Duration, limit uint) []strategy.Strategy {
+	limit += 1 // Fix for change in behavior: https://github.com/Rican7/retry/pull/12
 	backoff := backoff.BinaryExponential(factor)
 
 	strategies := []strategy.Strategy{}
 
-	if limit > 0 {
+	if limit > 1 {
 		strategies = append(strategies, strategy.Limit(limit))
 	}
 

--- a/internal/protocol/connector_test.go
+++ b/internal/protocol/connector_test.go
@@ -35,7 +35,7 @@ func TestConnector_Success(t *testing.T) {
 	assert.NoError(t, client.Close())
 
 	check([]string{
-		"DEBUG: attempt 0: server @test-0: connected",
+		"DEBUG: attempt 1: server @test-0: connected",
 	})
 }
 
@@ -53,9 +53,9 @@ func TestConnector_LimitRetries(t *testing.T) {
 	assert.Equal(t, protocol.ErrNoAvailableLeader, err)
 
 	check([]string{
-		"WARN: attempt 0: server @test-123: dial: dial unix @test-123: connect: connection refused",
 		"WARN: attempt 1: server @test-123: dial: dial unix @test-123: connect: connection refused",
 		"WARN: attempt 2: server @test-123: dial: dial unix @test-123: connect: connection refused",
+		"WARN: attempt 3: server @test-123: dial: dial unix @test-123: connect: connection refused",
 	})
 }
 
@@ -73,8 +73,8 @@ func TestConnector_DialTimeout(t *testing.T) {
 	assert.Equal(t, protocol.ErrNoAvailableLeader, err)
 
 	check([]string{
-		"WARN: attempt 0: server 8.8.8.8:9000: dial: dial tcp 8.8.8.8:9000: i/o timeout",
 		"WARN: attempt 1: server 8.8.8.8:9000: dial: dial tcp 8.8.8.8:9000: i/o timeout",
+		"WARN: attempt 2: server 8.8.8.8:9000: dial: dial tcp 8.8.8.8:9000: i/o timeout",
 	})
 }
 
@@ -107,7 +107,7 @@ func TestConnector_ContextCanceled(t *testing.T) {
 	assert.Equal(t, protocol.ErrNoAvailableLeader, err)
 
 	check([]string{
-		"WARN: attempt 0: server 1.2.3.4:666: dial: dial tcp 1.2.3.4:666: i/o timeout",
+		"WARN: attempt 1: server 1.2.3.4:666: dial: dial tcp 1.2.3.4:666: i/o timeout",
 	})
 }
 


### PR DESCRIPTION
Fix tests as result of API breakage of updated package.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>

fixes https://github.com/canonical/go-dqlite/issues/190