### PR TITLE
internal/bindings/server: don't use bad dqlite_node

### DIFF
--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -85,6 +85,12 @@ import (
 	"github.com/canonical/go-dqlite/internal/protocol"
 )
 
+const (
+	DQLITE_ERROR = 1
+	DQLITE_MISUSE = 2
+	DQLITE_NOMEM = 3
+)
+
 type Node struct {
 	node   *C.dqlite_node
 	ctx    context.Context
@@ -128,8 +134,16 @@ func NewNode(ctx context.Context, id uint64, address string, dir string) (*Node,
 	defer C.free(unsafe.Pointer(cdir))
 
 	if rc := C.dqlite_node_create(cid, caddress, cdir, &server); rc != 0 {
-		errmsg := C.GoString(C.dqlite_node_errmsg(server))
-		return nil, fmt.Errorf("%s", errmsg)
+		var errmsg string
+		switch rc {
+		case DQLITE_ERROR:
+			errmsg = "internal dqlite error"
+		case DQLITE_MISUSE:
+			errmsg = "misuse of dqlite API"
+		case DQLITE_NOMEM:
+			errmsg = "out of memory"
+		}
+		return nil, fmt.Errorf("failed to create node: %s", errmsg)
 	}
 
 	node := &Node{node: (*C.dqlite_node)(unsafe.Pointer(server))}


### PR DESCRIPTION
If dqlite_node_create fails, the `struct dqlite_node *` argument is set to NULL, so we shouldn't try to dereference it.

Discovered while investigating https://github.com/canonical/raft/issues/228.

Signed-off-by: Cole Miller <cole.miller@canonical.com>