### PR TITLE
style: Normalize error strings

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -58,7 +58,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 	if o.Conn != nil {
 		listener, err := net.Listen("unix", o.UnixSocket)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to autobind unix socket: %w", err)
+			return nil, fmt.Errorf("failed to autobind unix socket: %w", err)
 		}
 
 		nodeBindAddress = listener.Addr().String()
@@ -276,13 +276,13 @@ func New(dir string, options ...Option) (app *App, err error) {
 				n, err := remote.Write(data)
 				if err != nil || n != len(data) {
 					remote.Close()
-					panic(fmt.Errorf("Failed to write connection header: %w", err))
+					panic(fmt.Errorf("failed to write connection header: %w", err))
 				}
 
 				local, err := net.Dial("unix", nodeBindAddress)
 				if err != nil {
 					remote.Close()
-					panic(fmt.Errorf("Failed to connect to bind address %q: %w", nodeBindAddress, err))
+					panic(fmt.Errorf("failed to connect to bind address %q: %w", nodeBindAddress, err))
 				}
 
 				go proxy(app.ctx, remote, local, nil)
@@ -662,7 +662,7 @@ func (a *App) makeRolesChanges(nodes []client.NodeInfo) RolesChanges {
 		// sem.Acquire will not block forever because the goroutines
 		// that release the semaphore will eventually timeout.
 		if err := sem.Acquire(context.Background(), 1); err != nil {
-			a.warn("Failed to acquire semaphore: %v", err)
+			a.warn("failed to acquire semaphore: %v", err)
 			wg.Done()
 			continue
 		}

--- a/app/options.go
+++ b/app/options.go
@@ -258,7 +258,7 @@ func defaultAddress() (addr string, err error) {
 		}
 	}
 
-	return "", fmt.Errorf("No suitable net.Interface found: %v", err)
+	return "", fmt.Errorf("no suitable net.Interface found: %v", err)
 }
 
 func defaultLogFunc(l client.LogLevel, format string, a ...interface{}) {

--- a/app/proxy.go
+++ b/app/proxy.go
@@ -110,7 +110,7 @@ func extractTCPConn(conn net.Conn) (*net.TCPConn, error) {
 	// remote.conn field, which is indeed the underlying TCP connection.
 	tlsConn, ok := conn.(*tls.Conn)
 	if !ok {
-		return nil, fmt.Errorf("Connection is not a tls.Conn")
+		return nil, fmt.Errorf("connection is not a tls.Conn")
 	}
 
 	field := reflect.ValueOf(tlsConn).Elem().FieldByName("conn")
@@ -119,7 +119,7 @@ func extractTCPConn(conn net.Conn) (*net.TCPConn, error) {
 
 	tcpConn, ok := c.(*net.TCPConn)
 	if !ok {
-		return nil, fmt.Errorf("Connection is not a net.TCPConn")
+		return nil, fmt.Errorf("connection is not a net.TCPConn")
 	}
 
 	return tcpConn, nil

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -94,18 +94,18 @@ func (bm *Benchmark) reportFiles() map[string]string {
 func (bm *Benchmark) reportResults() error {
 	dir := path.Join(bm.dir, "results")
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("Failed to create %v: %v", dir, err)
+		return fmt.Errorf("failed to create %v: %v", dir, err)
 	}
 
 	reports := bm.reportFiles()
 	for filename, content := range reports {
 		f, err := os.Create(path.Join(dir, filename))
 		if err != nil {
-			return fmt.Errorf("Failed to create %v in %v: %v", filename, dir, err)
+			return fmt.Errorf("failed to create %v in %v: %v", filename, dir, err)
 		}
 		_, err = f.WriteString(content)
 		if err != nil {
-			return fmt.Errorf("Failed to write %v in %v: %v", filename, dir, err)
+			return fmt.Errorf("failed to write %v in %v: %v", filename, dir, err)
 		}
 		f.Sync()
 	}
@@ -164,11 +164,11 @@ func (bm *Benchmark) waitForCluster(ch <-chan os.Signal) error {
 	select {
 	case <-ctx.Done():
 		if !errors.Is(ctx.Err(), context.Canceled) {
-			return fmt.Errorf("Timed out waiting for cluster: %v", ctx.Err())
+			return fmt.Errorf("timed out waiting for cluster: %v", ctx.Err())
 		}
 		return nil
 	case <-ch:
-		return fmt.Errorf("Benchmark stopped. Signal received while waiting for cluster.")
+		return fmt.Errorf("benchmark stopped, signal received while waiting for cluster")
 	}
 
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -376,7 +376,7 @@ func (c *Conn) Prepare(query string) (driver.Stmt, error) {
 // ExecContext is an optional interface that may be implemented by a Conn.
 func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	if len(args) > MaxTupleParams {
-		return nil, driverError(c.log, fmt.Errorf("too many parameters (%d) max = %d.", len(args), MaxTupleParams))
+		return nil, driverError(c.log, fmt.Errorf("too many parameters (%d) max = %d", len(args), MaxTupleParams))
 	}
 
 	protocol.EncodeExecSQL(&c.request, uint64(c.id), query, args)
@@ -405,7 +405,7 @@ func (c *Conn) Query(query string, args []driver.Value) (driver.Rows, error) {
 // QueryContext is an optional interface that may be implemented by a Conn.
 func (c *Conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	if len(args) > MaxTupleParams {
-		return nil, driverError(c.log, fmt.Errorf("too many parameters (%d) max = %d.", len(args), MaxTupleParams))
+		return nil, driverError(c.log, fmt.Errorf("too many parameters (%d) max = %d", len(args), MaxTupleParams))
 	}
 
 	protocol.EncodeQuerySQL(&c.request, uint64(c.id), query, args)
@@ -558,7 +558,7 @@ func (s *Stmt) NumInput() int {
 // ExecContext must honor the context timeout and return when it is canceled.
 func (s *Stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
 	if len(args) > MaxTupleParams {
-		return nil, driverError(s.log, fmt.Errorf("too many parameters (%d) max = %d.", len(args), MaxTupleParams))
+		return nil, driverError(s.log, fmt.Errorf("too many parameters (%d) max = %d", len(args), MaxTupleParams))
 	}
 
 	protocol.EncodeExec(s.request, s.db, s.id, args)
@@ -590,7 +590,7 @@ func (s *Stmt) Exec(args []driver.Value) (driver.Result, error) {
 // QueryContext must honor the context timeout and return when it is canceled.
 func (s *Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
 	if len(args) > MaxTupleParams {
-		return nil, driverError(s.log, fmt.Errorf("too many parameters (%d) max = %d.", len(args), MaxTupleParams))
+		return nil, driverError(s.log, fmt.Errorf("too many parameters (%d) max = %d", len(args), MaxTupleParams))
 	}
 
 	protocol.EncodeQuery(s.request, s.db, s.id, args)

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -262,17 +262,17 @@ func (s *Shell) processReconfigure(ctx context.Context, line string) (string, er
 
 	store, err := client.NewYamlNodeStore(clusteryamlpath)
 	if err != nil {
-		return "NOK", fmt.Errorf("Failed to create YamlNodeStore from file at %s :%v", clusteryamlpath, err)
+		return "NOK", fmt.Errorf("failed to create YamlNodeStore from file at %s :%v", clusteryamlpath, err)
 	}
 
 	servers, err := store.Get(ctx)
 	if err != nil {
-		return "NOK", fmt.Errorf("Failed to retrieve NodeInfo list :%v", err)
+		return "NOK", fmt.Errorf("failed to retrieve NodeInfo list :%v", err)
 	}
 
 	err = dqlite.ReconfigureMembershipExt(dir, servers)
 	if err != nil {
-		return "NOK", fmt.Errorf("Failed to reconfigure membership :%v.", err)
+		return "NOK", fmt.Errorf("failed to reconfigure membership :%v", err)
 	}
 
 	return "OK", nil


### PR DESCRIPTION
We use the conventional Go style: no initial capitalization, no final
punctuation. See
https://github.com/golang/go/wiki/CodeReviewComments#error-strings.

As discussed in #196.

Signed-off-by: Cole Miller <cole.miller@canonical.com>