### PR TITLE
Account for new dqlite_node_create guidelines

### DIFF
--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -129,6 +129,7 @@ func NewNode(ctx context.Context, id uint64, address string, dir string) (*Node,
 
 	if rc := C.dqlite_node_create(cid, caddress, cdir, &server); rc != 0 {
 		errmsg := C.GoString(C.dqlite_node_errmsg(server))
+		C.dqlite_node_destroy(server)
 		return nil, fmt.Errorf("%s", errmsg)
 	}
 

--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -85,12 +85,6 @@ import (
 	"github.com/canonical/go-dqlite/internal/protocol"
 )
 
-const (
-	DQLITE_ERROR = 1
-	DQLITE_MISUSE = 2
-	DQLITE_NOMEM = 3
-)
-
 type Node struct {
 	node   *C.dqlite_node
 	ctx    context.Context
@@ -134,16 +128,8 @@ func NewNode(ctx context.Context, id uint64, address string, dir string) (*Node,
 	defer C.free(unsafe.Pointer(cdir))
 
 	if rc := C.dqlite_node_create(cid, caddress, cdir, &server); rc != 0 {
-		var errmsg string
-		switch rc {
-		case DQLITE_ERROR:
-			errmsg = "internal dqlite error"
-		case DQLITE_MISUSE:
-			errmsg = "misuse of dqlite API"
-		case DQLITE_NOMEM:
-			errmsg = "out of memory"
-		}
-		return nil, fmt.Errorf("failed to create node: %s", errmsg)
+		errmsg := C.GoString(C.dqlite_node_errmsg(server))
+		return nil, fmt.Errorf("%s", errmsg)
 	}
 
 	node := &Node{node: (*C.dqlite_node)(unsafe.Pointer(server))}


### PR DESCRIPTION
In https://github.com/canonical/dqlite/pull/381 I've updated dqlite to expose a valid `errmsg` even when `dqlite_node_create` fails. A consequence is that callers are now supposed to call `dqlite_node_destroy` even after a failure to release the memory allocated for `errmsg` and other fields. This PR reverts the earlier fix #196 and updated go-dqlite's usage of `dqlite_node_create`/`dqlite_node_destroy` to match the new convention.

Signed-off-by: Cole Miller <cole.miller@canonical.com>