### PR TITLE
app: Don't transfer leadership more than once

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -367,6 +367,7 @@ func (a *App) Handover(ctx context.Context) error {
 				return fmt.Errorf("find new leader: %w", err)
 			}
 			defer cli.Close()
+			break
 		}
 	}
 


### PR DESCRIPTION
In the `Handover` method of `App`, after successfully transferring leadership to another node, we shouldn't continue looping over other servers and trying to transfer to them. Spotted by @MathieuBordere.

Signed-off-by: Cole Miller <cole.miller@canonical.com>