### PR TITLE
github: Run go test in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,6 +44,7 @@ jobs:
         deadcode
         export GO_DQLITE_MULTITHREAD=1
         overalls -project ${{ github.workspace }} -covermode=count -- -tags libsqlite3 -timeout 240s
+        go test -v ./...
         VERBOSE=1 ./test/dqlite-demo.sh
         VERBOSE=1 ./test/roles.sh
         VERBOSE=1 ./test/recover.sh


### PR DESCRIPTION
We already run `go test` on Launchpad, but not for pull requests. Not sure whether there's a reason for that, so I'm opening this PR to facilitate discussion.

Signed-off-by: Cole Miller <cole.miller@canonical.com>