### PR TITLE
Revert "github: Run go test in CI"

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,6 @@ jobs:
         deadcode
         export GO_DQLITE_MULTITHREAD=1
         overalls -project ${{ github.workspace }} -covermode=count -- -tags libsqlite3 -timeout 240s
-        go test -v ./...
         VERBOSE=1 ./test/dqlite-demo.sh
         VERBOSE=1 ./test/roles.sh
         VERBOSE=1 ./test/recover.sh


### PR DESCRIPTION
Reverts #201. @MathieuBordere pointed out that overalls already runs all tests in the project, including printing a report for test failures. So we don't need to run `go test ./...` separately after all.

https://github.com/canonical/go-dqlite/blob/bca58cd1b7af8555ce118b45f34e95330f397307/.github/workflows/build-and-test.yml#L46

Signed-off-by: Cole Miller <cole.miller@canonical.com>