### PR TITLE
Shell fixes

### DIFF
--- a/cmd/dqlite/dqlite.go
+++ b/cmd/dqlite/dqlite.go
@@ -116,8 +116,11 @@ func main() {
 				result, err := sh.Process(context.Background(), input)
 				if err != nil {
 					fmt.Println("Error: ", err)
-				} else if result != "" {
-					fmt.Println(result)
+				} else {
+					line.AppendHistory(input)
+					if result != "" {
+						fmt.Println(result)
+					}
 				}
 			}
 


### PR DESCRIPTION
- Fix a bug where a user could lock a running database by issuing a failing transaction that was never rolled back. Some projects use the shell so could happen in non-toy examples. I ran into it when trying to insert a row that violates a UNIQUE key constraint, locking my DB for further inserts.
- Add successful commands to the shell history (by default limited to 1000 entries). Up & Down arrow keys will behave as expected in the `dqlite` shell.