### PR TITLE
Don't require number of standbys to be odd

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -220,11 +220,6 @@ func New(dir string, options ...Option) (app *App, err error) {
 		return nil, fmt.Errorf("invalid voters %d: must be an odd number greater than 1", o.Voters)
 	}
 
-	if o.StandBys%2 == 0 {
-		stop()
-		return nil, fmt.Errorf("invalid stand-bys %d: must be an odd number", o.StandBys)
-	}
-
 	if runtime.GOOS != "linux" && nodeBindAddress[0] == '@' {
 		// Do not use abstract socket on other platforms and left trim "@"
 		nodeBindAddress = nodeBindAddress[1:]

--- a/app/options.go
+++ b/app/options.go
@@ -120,8 +120,6 @@ func WithVoters(n int) Option {
 // All App instances in a cluster must be created with the same WithStandBys
 // setting.
 //
-// The given value must be an odd number.
-//
 // The default value is 3.
 func WithStandBys(n int) Option {
 	return func(options *options) {


### PR DESCRIPTION
It makes sense to require that the configured number of voters be odd, because that avoids ties in raft elections. But I don't see any reason to require that the number of standby nodes be odd. Please correct me if there's something I'm missing!

Signed-off-by: Cole Miller <cole.miller@canonical.com>