### PR TITLE
Add go 1.19

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,6 @@ jobs:
         sudo add-apt-repository ppa:dqlite/dev -y
         sudo apt update
         sudo apt install -y golint libsqlite3-dev libuv1-dev liblz4-dev libraft-dev libdqlite-dev
-        go get github.com/tsenart/deadcode
         go get github.com/go-playground/overalls
 
     - name: Build & Test
@@ -48,7 +47,6 @@ jobs:
         go get -t -tags libsqlite3 ./...
         go vet -tags libsqlite3 ./...
         golint
-        deadcode
         export GO_DQLITE_MULTITHREAD=1
         overalls -project ${{ github.workspace }} -covermode=count -- -tags libsqlite3 -timeout 240s
         VERBOSE=1 DISK=${{ matrix.disk }} ./test/dqlite-demo.sh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,7 +48,7 @@ jobs:
         go vet -tags libsqlite3 ./...
         golint
         export GO_DQLITE_MULTITHREAD=1
-        overalls -project ${{ github.workspace }} -covermode=count -- -tags libsqlite3 -timeout 240s
+        go test -v -coverprofile=coverage.out ./...
         VERBOSE=1 DISK=${{ matrix.disk }} ./test/dqlite-demo.sh
         VERBOSE=1 DISK=${{ matrix.disk }} ./test/roles.sh
         VERBOSE=1 DISK=${{ matrix.disk }} ./test/recover.sh
@@ -56,7 +56,7 @@ jobs:
     - name: Coverage
       uses: shogo82148/actions-goveralls@v1
       with:
-        path-to-profile: overalls.coverprofile
+        path-to-profile: coverage.out
 
     - name: Benchmark
       env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,9 +13,12 @@ jobs:
           - 1.14.x
           - 1.15.x
           - 1.16.x
+          - 1.17.x
+          - 1.18.x
+          - 1.19.x
         os:
-          - ubuntu-18.04
           - ubuntu-20.04
+          - ubuntu-22.04
         disk:
           - 1
           - 0
@@ -41,6 +44,7 @@ jobs:
       env:
         CGO_LDFLAGS_ALLOW: "-Wl,-z,now"
       run: |
+        go version
         go get -t -tags libsqlite3 ./...
         go vet -tags libsqlite3 ./...
         golint

--- a/app/example_test.go
+++ b/app/example_test.go
@@ -28,7 +28,6 @@ func Example() {
 	}
 
 	fmt.Printf("0x%x %s\n", node.ID(), node.Address())
-	// Output: 0x2dc171858c3155be 127.0.0.1:9001
 
 	if err := node.Close(); err != nil {
 		return
@@ -92,7 +91,7 @@ func ExampleWithCluster() {
 	}
 
 	fmt.Println(node1.ID() != node2.ID(), node1.ID() != node3.ID(), node2.ID() != node3.ID())
-	// Output: true true true
+	// true true true
 
 	// Restart the third node, the only argument we need to pass to
 	// app.New() is its dir.

--- a/app/tls.go
+++ b/app/tls.go
@@ -4,8 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-
-	"github.com/canonical/go-dqlite/internal/protocol"
 )
 
 // SimpleTLSConfig returns a pair of TLS configuration objects with sane
@@ -60,17 +58,15 @@ func SimpleTLSConfig(cert tls.Certificate, pool *x509.CertPool) (*tls.Config, *t
 //
 // The returned config can be used as "listen" parameter for the WithTLS
 // option.
+//
+// A user can modify the returned config to suit their specifig needs.
 func SimpleListenTLSConfig(cert tls.Certificate, pool *x509.CertPool) *tls.Config {
-	// See https://github.com/denji/golang-tls
 	config := &tls.Config{
-		MinVersion:               tls.VersionTLS12,
-		CipherSuites:             protocol.TLSCipherSuites,
-		PreferServerCipherSuites: true,
-		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
-		Certificates:             []tls.Certificate{cert},
-		RootCAs:                  pool,
-		ClientCAs:                pool,
-		ClientAuth:               tls.RequireAndVerifyClientCert,
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      pool,
+		ClientCAs:    pool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
 	}
 	config.BuildNameToCertificate()
 
@@ -96,14 +92,14 @@ func SimpleListenTLSConfig(cert tls.Certificate, pool *x509.CertPool) *tls.Confi
 // TLS connections using the same `Config` will share a ClientSessionCache.
 // You can override this behaviour by setting your own ClientSessionCache or
 // nil.
+//
+// A user can modify the returned config to suit their specifig needs.
 func SimpleDialTLSConfig(cert tls.Certificate, pool *x509.CertPool) *tls.Config {
 	config := &tls.Config{
-		MinVersion:               tls.VersionTLS12,
-		CipherSuites:             protocol.TLSCipherSuites,
-		PreferServerCipherSuites: true,
-		RootCAs:                  pool,
-		Certificates:             []tls.Certificate{cert},
-		ClientSessionCache:       tls.NewLRUClientSessionCache(256),
+		MinVersion:         tls.VersionTLS12,
+		RootCAs:            pool,
+		Certificates:       []tls.Certificate{cert},
+		ClientSessionCache: tls.NewLRUClientSessionCache(256),
 	}
 
 	x509cert, err := x509.ParseCertificate(cert.Certificate[0])

--- a/cmd/dqlite-benchmark/dqlite-benchmark.go
+++ b/cmd/dqlite-benchmark/dqlite-benchmark.go
@@ -44,7 +44,7 @@ const (
 )
 
 func signalChannel() chan os.Signal {
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 32)
 	signal.Notify(ch, unix.SIGPWR)
 	signal.Notify(ch, unix.SIGINT)
 	signal.Notify(ch, unix.SIGQUIT)

--- a/cmd/dqlite-demo/dqlite-demo.go
+++ b/cmd/dqlite-demo/dqlite-demo.go
@@ -92,7 +92,7 @@ Complete documentation is available at https://github.com/canonical/go-dqlite`,
 
 			go http.Serve(listener, nil)
 
-			ch := make(chan os.Signal)
+			ch := make(chan os.Signal, 32)
 			signal.Notify(ch, unix.SIGPWR)
 			signal.Notify(ch, unix.SIGINT)
 			signal.Notify(ch, unix.SIGQUIT)

--- a/driver/integration_test.go
+++ b/driver/integration_test.go
@@ -111,7 +111,7 @@ func TestIntegration_ExecBindError(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = db.ExecContext(ctx, "INSERT INTO test(n) VALUES(1)", 1)
-	assert.EqualError(t, err, "column index out of range")
+	assert.EqualError(t, err, "bind parameters")
 }
 
 func TestIntegration_QueryBindError(t *testing.T) {
@@ -123,7 +123,7 @@ func TestIntegration_QueryBindError(t *testing.T) {
 	defer cancel()
 
 	_, err := db.QueryContext(ctx, "SELECT 1", 1)
-	assert.EqualError(t, err, "column index out of range")
+	assert.EqualError(t, err, "bind parameters")
 }
 
 func TestIntegration_ConfigMultiThread(t *testing.T) {

--- a/internal/protocol/dial.go
+++ b/internal/protocol/dial.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"context"
-	"crypto/tls"
 	"net"
 	"strings"
 )
@@ -15,16 +14,4 @@ func Dial(ctx context.Context, address string) (net.Conn, error) {
 	}
 	dialer := net.Dialer{}
 	return dialer.DialContext(ctx, family, address)
-}
-
-// TLSCipherSuites are the cipher suites by the go-dqlite TLS helpers.
-var TLSCipherSuites = []uint16{
-	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
 }


### PR DESCRIPTION
This PR introduces:

 - Update SimpleTLSConfig: The current config doesn't seem to be compatible with `go 1.19.6` making connections fail with `write handshake: local error: tls: bad record MAC` see e.g. [here](https://github.com/canonical/go-dqlite/actions/runs/4342334566/jobs/7583025948), don't know root cause yet and it's probably not a good idea to wait for a new go release if it would indeed be a bug in go (which it is probably not). 
  The config in this PR fixes the issue. Anyone has an opinion on the proposed config in this PR?
- Run CI on Ubuntu 22.04.
- Disable running CI on Ubuntu 18.04
- Add go versions until 1.19 to CI.
- Fix some issues when upgrading to `go 1.19.x` 
  - removing `deadcode`, `overalls`
  - used buffered channel for os.Signal
  - make sure there's only 1 Output comment at end of function

edit: Just removing the curve preferences from the config seems to also fix the issue, this is probably a safer bet than also forcing TLS 1.3
  