### PR TITLE
tls: Disable clientsessioncache

### DIFF
--- a/app/tls.go
+++ b/app/tls.go
@@ -96,10 +96,9 @@ func SimpleListenTLSConfig(cert tls.Certificate, pool *x509.CertPool) *tls.Confi
 // A user can modify the returned config to suit their specifig needs.
 func SimpleDialTLSConfig(cert tls.Certificate, pool *x509.CertPool) *tls.Config {
 	config := &tls.Config{
-		MinVersion:         tls.VersionTLS12,
-		RootCAs:            pool,
-		Certificates:       []tls.Certificate{cert},
-		ClientSessionCache: tls.NewLRUClientSessionCache(256),
+		MinVersion:   tls.VersionTLS12,
+		RootCAs:      pool,
+		Certificates: []tls.Certificate{cert},
 	}
 
 	x509cert, err := x509.ParseCertificate(cert.Certificate[0])


### PR DESCRIPTION
The `ClientCessionCache` causes incompatibilities between go-dqlite `1.11.6` and `1.11.7`.

go-dqlite `1.11.7` contains a new SimpleTLSConfig that eliminated incompatibilities with go 1.19.6 and newer. However, it seems nodes running go-dqlite versions older than `1.11.7` throw TLS errors when communication with modern nodes if the `ClientCessionCache` is enabled.

So, disable the `ClientCessionCache` by default. Users can still opt to enable it by adapting the client config returned by `SimpleTLSConfig`.