### PR TITLE
Adjust dependencies to make it possible to statically link dqlite.

### DIFF
--- a/internal/bindings/build.go
+++ b/internal/bindings/build.go
@@ -1,6 +1,6 @@
 package bindings
 
 /*
-#cgo linux LDFLAGS: -lraft -ldqlite -Wl,-z,now
+#cgo linux LDFLAGS: -ldqlite -lraft -llz4 -luv_a -lm -Wl,-z,now
 */
 import "C"


### PR DESCRIPTION
Hi. Currently, if you try to build a statically linked executable you'll see a lot of errors like:
```
$ CGO_LDFLAGS="-static" CGO_LDFLAGS_ALLOW="-Wl,-z,now" go build -tags libsqlite3 ./cmd/dqlite-demo
....
(.text+0x3b8): undefined reference to `uv_read_start'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/11/../../../x86_64-linux-gnu/libdqlite.a(transport.o): in function `transport__close':
(.text+0x351): undefined reference to `uv_close'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/11/../../../x86_64-linux-gnu/libdqlite.a(transport.o): in function `transport__write':
(.text+0x440): undefined reference to `uv_write'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/11/../../../x86_64-linux-gnu/libdqlite.a(command.o): in function `command__encode':
(.text+0x74a): undefined reference to `raft_malloc'
/usr/bin/ld: (.text+0x7e0): undefined reference to `raft_malloc'
/usr/bin/ld: (.text+0x86b): undefined reference to `raft_malloc'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/11/../../../x86_64-linux-gnu/libdqlite.a(command.o): in function `command__decode':
(.text+0x92b): undefined reference to `raft_malloc'
/usr/bin/ld: (.text+0x99c): undefined reference to `raft_malloc'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/11/../../../x86_64-linux-gnu/libdqlite.a(command.o):(.text+0x9e6): more undefined references to `raft_malloc' follow
collect2: error: ld returned 1 exit status
```
To get rid of these errors we need to ensure that all of dqlite's dependencies are also linked to the executable. So we need to specify them in the correct order after the dqlite library itself.