### PR TITLE
Provide tracing options at the app level

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -212,7 +212,12 @@ func New(dir string, options ...Option) (app *App, err error) {
 		driverDial = o.Conn.dialFunc
 	}
 
-	driver, err := driver.New(store, driver.WithDialFunc(driverDial), driver.WithLogFunc(o.Log))
+	driver, err := driver.New(
+		store,
+		driver.WithDialFunc(driverDial),
+		driver.WithLogFunc(o.Log),
+		driver.WithTracing(o.Tracing),
+	)
 	if err != nil {
 		stop()
 		return nil, fmt.Errorf("create driver: %w", err)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -890,6 +890,7 @@ func TestOptions(t *testing.T) {
 		app.WithAddress("127.0.0.1:9000"),
 		app.WithNetworkLatency(20 * time.Millisecond),
 		app.WithSnapshotParams(dqlite.SnapshotParams{Threshold: 1024, Trailing: 1024}),
+		app.WithTracing(client.LogDebug),
 	}
 	app, cleanup := newApp(t, options...)
 	defer cleanup()

--- a/app/options.go
+++ b/app/options.go
@@ -146,6 +146,14 @@ func WithLogFunc(log client.LogFunc) Option {
 	}
 }
 
+// WithTracing will emit a log message at the given level every time a
+// statement gets executed.
+func WithTracing(level client.LogLevel) Option {
+	return func(options *options) {
+		options.Tracing = level
+	}
+}
+
 // WithFailureDomain sets the node's failure domain.
 //
 // Failure domains are taken into account when deciding which nodes to promote
@@ -195,6 +203,7 @@ type options struct {
 	Address                  string
 	Cluster                  []string
 	Log                      client.LogFunc
+	Tracing                  client.LogLevel
 	TLS                      *tlsSetup
 	Conn                     *connSetup
 	Voters                   int
@@ -211,6 +220,7 @@ type options struct {
 func defaultOptions() *options {
 	return &options{
 		Log:                      defaultLogFunc,
+		Tracing:                  client.LogNone,
 		Voters:                   3,
 		StandBys:                 3,
 		RolesAdjustmentFrequency: 30 * time.Second,


### PR DESCRIPTION
The following provides the tracing options at the app level, so we can then pass them directly to the driver. This will allow monitoring of the traces provided by the driver.

This approach will suffice for now, but might be better to rethink how we expose driver capabilities in the future.

Fixes: #242