### PR TITLE
app_test: Close App before removing dir in TestParallell.

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1056,8 +1056,8 @@ func TestParallelNewApp(t *testing.T) {
 			)
 			require.NoError(tt, err)
 			defer func() {
-				_ = os.RemoveAll(tmpDir)
 				_ = dqApp.Close()
+				_ = os.RemoveAll(tmpDir)
 			}()
 		})
 	}


### PR DESCRIPTION
The app can still write to the directory and mess with future tests that expect an empty dir.

should fix #237 