### PR TITLE
Allow BEGIN CONCURRENT for transactions

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -218,6 +218,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 		driver.WithDialFunc(driverDial),
 		driver.WithLogFunc(o.Log),
 		driver.WithTracing(o.Tracing),
+		driver.WithTxMode(o.TxMode),
 	)
 	if err != nil {
 		stop()

--- a/app/options.go
+++ b/app/options.go
@@ -189,6 +189,14 @@ func WithDiskMode(disk bool) Option {
 	}
 }
 
+// WithTxMode sets the custom transaction mode between BEGIN and
+// BEGIN CONCURRENT.
+func WithTxMode(mode client.TxMode) Option {
+	return func(options *options) {
+		options.TxMode = mode
+	}
+}
+
 type tlsSetup struct {
 	Listen *tls.Config
 	Dial   *tls.Config
@@ -214,6 +222,7 @@ type options struct {
 	UnixSocket               string
 	SnapshotParams           dqlite.SnapshotParams
 	DiskMode                 bool
+	TxMode                   client.TxMode
 }
 
 // Create a options object with sane defaults.
@@ -225,6 +234,7 @@ func defaultOptions() *options {
 		StandBys:                 3,
 		RolesAdjustmentFrequency: 30 * time.Second,
 		DiskMode:                 false, // Be explicit about not enabling disk-mode by default.
+		TxMode:                   client.TxModeBegin,
 	}
 }
 
@@ -235,18 +245,18 @@ func isLoopback(iface *net.Interface) bool {
 // see https://stackoverflow.com/a/48519490/3613657
 // Valid IPv4 notations:
 //
-//    "192.168.0.1": basic
-//    "192.168.0.1:80": with port info
+//	"192.168.0.1": basic
+//	"192.168.0.1:80": with port info
 //
 // Valid IPv6 notations:
 //
-//    "::FFFF:C0A8:1": basic
-//    "::FFFF:C0A8:0001": leading zeros
-//    "0000:0000:0000:0000:0000:FFFF:C0A8:1": double colon expanded
-//    "::FFFF:C0A8:1%1": with zone info
-//    "::FFFF:192.168.0.1": IPv4 literal
-//    "[::FFFF:C0A8:1]:80": with port info
-//    "[::FFFF:C0A8:1%1]:80": with zone and port info
+//	"::FFFF:C0A8:1": basic
+//	"::FFFF:C0A8:0001": leading zeros
+//	"0000:0000:0000:0000:0000:FFFF:C0A8:1": double colon expanded
+//	"::FFFF:C0A8:1%1": with zone info
+//	"::FFFF:192.168.0.1": IPv4 literal
+//	"[::FFFF:C0A8:1]:80": with port info
+//	"[::FFFF:C0A8:1%1]:80": with zone and port info
 func isIpV4(ip string) bool {
 	return strings.Count(ip, ":") < 2
 }

--- a/client/mode.go
+++ b/client/mode.go
@@ -1,0 +1,14 @@
+package client
+
+// TxMode defines the transaction mode to use when opening a new transaction.
+type TxMode = int
+
+const (
+	// TxModeBegin is the default transaction mode.
+	TxModeBegin TxMode = iota
+
+	// TxModeBeginConcurrent is a custom transaction mode that allows multiple
+	// writers to process write transactions simultaneously.
+	// https://www.sqlite.org/cgi/src/doc/begin-concurrent/doc/begin_concurrent.md#:~:text=Overview,system%20still%20serializes%20COMMIT%20commands.
+	TxModeBeginConcurrent
+)


### PR DESCRIPTION
The following implements a TxMode for testing purposes. The idea being we would like to see if there is any performance difference in using BEGIN CONCURRENT or not in juju.

The notion is simple, we pass a option through the App and to the driver and based on the value of the option we switch the tx start mode.