### PR TITLE
test: Allow building test binaries with -asan

### DIFF
--- a/test/dqlite-demo-util.sh
+++ b/test/dqlite-demo-util.sh
@@ -1,10 +1,11 @@
 # dqlite-demo test utilities
 
 GO=${GO:-go}
+ASAN=${ASAN:-}
 VERBOSE=${VERBOSE:-0}
 DISK=${DISK:-0}
 
-$GO build -tags libsqlite3 ./cmd/dqlite-demo/
+$GO build -tags libsqlite3 $ASAN ./cmd/dqlite-demo/
 
 DIR=$(mktemp -d)
 

--- a/test/recover.sh
+++ b/test/recover.sh
@@ -2,10 +2,12 @@
 #
 # Test the dqlite cluster recovery.
 
+ASAN=${ASAN:-}
+
 BASEDIR=$(dirname "$0")
 . "$BASEDIR"/dqlite-demo-util.sh
 
-$GO build -tags libsqlite3 ./cmd/dqlite/
+$GO build -tags libsqlite3 $ASAN ./cmd/dqlite/
 
 trap tear_down EXIT
 trap sig_handler HUP INT TERM

--- a/test/roles.sh
+++ b/test/roles.sh
@@ -3,6 +3,7 @@
 # Test dynamic roles management.
 
 GO=${GO:-go}
+ASAN=${ASAN:-}
 VERBOSE=${VERBOSE:-0}
 DIR=$(mktemp -d)
 BINARY=$DIR/main
@@ -10,7 +11,7 @@ CLUSTER=127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003,127.0.0.1:9004,127.0.0.1:90
 N=7
 DISK=${DISK:-0}
 
-$GO build -tags libsqlite3 ./cmd/dqlite/
+$GO build -tags libsqlite3 $ASAN ./cmd/dqlite/
 
 
 set_up_binary() {


### PR DESCRIPTION
For the general "downstream testing" push, I would like to be able to run all the go-dqlite tests against a libdqlite.so that was built with ASan. For shell script tests that call `go build` explicitly, we need to allow adding `-asan` to the invocation, and that's what this PR implements.

Signed-off-by: Cole Miller <cole.miller@canonical.com>