### PR TITLE
Export raw SQLite result codes

### DIFF
--- a/internal/protocol/errors.go
+++ b/internal/protocol/errors.go
@@ -16,7 +16,9 @@ var (
 
 // ErrRequest is returned in case of request failure.
 type ErrRequest struct {
+	// A SQLite-compatible error code.
 	Code        uint64
+	// A description of the error condition.
 	Description string
 }
 


### PR DESCRIPTION
Closes #259. My preference here is to export all these constants under their "C names", e.g. SQLITE_CONSTRAINT, to make their raw nature obvious, but I can switch this PR to Go-style names if @freeekanayaka or @MathieuBordere feel strongly about it.

Signed-off-by: Cole Miller <cole.miller@canonical.com>