### PR TITLE
Expose auto-recovery config switch from dqlite

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -194,6 +194,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 		dqlite.WithNetworkLatency(o.NetworkLatency),
 		dqlite.WithSnapshotParams(o.SnapshotParams),
 		dqlite.WithDiskMode(o.DiskMode),
+		dqlite.WithAutoRecovery(o.AutoRecovery),
 	)
 	if err != nil {
 		stop()

--- a/app/options.go
+++ b/app/options.go
@@ -189,6 +189,20 @@ func WithDiskMode(disk bool) Option {
 	}
 }
 
+// WithAutoRecovery enables or disables auto-recovery of persisted data
+// at startup for this node.
+//
+// When auto-recovery is enabled, raft snapshots and segment files may be
+// deleted at startup if they are determined to be corrupt. This helps
+// the startup process to succeed in more cases, but can lead to data loss.
+//
+// Auto-recovery is enabled by default.
+func WithAutoRecovery(recovery bool) Option {
+	return func(options *options) {
+		options.AutoRecovery = recovery
+	}
+}
+
 type tlsSetup struct {
 	Listen *tls.Config
 	Dial   *tls.Config
@@ -214,6 +228,7 @@ type options struct {
 	UnixSocket               string
 	SnapshotParams           dqlite.SnapshotParams
 	DiskMode                 bool
+	AutoRecovery             bool
 }
 
 // Create a options object with sane defaults.
@@ -225,6 +240,7 @@ func defaultOptions() *options {
 		StandBys:                 3,
 		RolesAdjustmentFrequency: 30 * time.Second,
 		DiskMode:                 false, // Be explicit about not enabling disk-mode by default.
+		AutoRecovery:             true,
 	}
 }
 

--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -183,6 +183,14 @@ func (s *Node) EnableDiskMode() error {
 	return nil
 }
 
+func (s *Node) SetAutoRecovery(on bool) error {
+	server := (*C.dqlite_node)(unsafe.Pointer(s.node))
+	if rc := C.dqlite_node_set_auto_recovery(server, C.bool(on)); rc != 0 {
+		return fmt.Errorf("failed to set auto-recovery behavior")
+	}
+	return nil
+}
+
 func (s *Node) GetBindAddress() string {
 	server := (*C.dqlite_node)(unsafe.Pointer(s.node))
 	return C.GoString(C.dqlite_node_get_bind_address(server))


### PR DESCRIPTION
See https://github.com/canonical/jepsen.dqlite/issues/110

Signed-off-by: Cole Miller <cole.miller@canonical.com>