### PR TITLE
driver: detect EOF on Connect and mark with ErrBadConn.

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -258,7 +258,7 @@ func (c *Connector) Connect(ctx context.Context) (driver.Conn, error) {
 	var err error
 	conn.protocol, err = connector.Connect(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create dqlite connection")
+		return nil, driverError(conn.log, errors.Wrap(err, "failed to create dqlite connection"))
 	}
 
 	conn.request.Init(4096)
@@ -268,13 +268,13 @@ func (c *Connector) Connect(ctx context.Context) (driver.Conn, error) {
 
 	if err := conn.protocol.Call(ctx, &conn.request, &conn.response); err != nil {
 		conn.protocol.Close()
-		return nil, errors.Wrap(err, "failed to open database")
+		return nil, driverError(conn.log, errors.Wrap(err, "failed to open database"))
 	}
 
 	conn.id, err = protocol.DecodeDb(&conn.response)
 	if err != nil {
 		conn.protocol.Close()
-		return nil, errors.Wrap(err, "failed to open database")
+		return nil, driverError(conn.log, errors.Wrap(err, "failed to open database"))
 	}
 
 	return conn, nil


### PR DESCRIPTION
This should fix #265 

When calling `app.Open` https://github.com/canonical/go-dqlite/blob/64c24c752b79f72bf12591a53939c9c31c27b96c/app/app.go#L462-L484

the call to `sql.Open` will always return `err == nil` because we don't implement `DriverContext` (see https://cs.opensource.google/go/go/+/refs/tags/go1.18.1:src/database/sql/sql.go;drc=894d24d617bb72d6e1bed7b143f9f7a0ac16b844;l=813

In the next phase of `app.Open`, `db.PingContext(ctx)` can fail if we've been given a connection that's been closed and returns `EOF` but is not marked with `errBadConn`. (see https://cs.opensource.google/go/go/+/refs/tags/go1.18.1:src/database/sql/sql.go;drc=2580d0e08d5e9f979b943758d3c49877fb2324cb;l=859)

The solution is to also call `driverError` in `connector.Connect` which will mark a connection with `errBadConn` if `EOF` is detected causing the sql package to retry with a new connection. `connector.Connect` is the location where the part of the error message `failed to open database` in #265 comes from.