### PR TITLE
OpenTelemetry Driver Tracing

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/canonical/go-dqlite/client"
 	"github.com/canonical/go-dqlite/internal/protocol"
+	"github.com/canonical/go-dqlite/tracing"
 )
 
 // Driver perform queries against a dqlite server.
@@ -339,6 +340,9 @@ type Conn struct {
 // context is for the preparation of the statement, it must not store the
 // context within the statement itself.
 func (c *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	ctx, span := tracing.Start(ctx, "dqlite.driver.PrepareContext", query)
+	defer span.End()
+
 	stmt := &Stmt{
 		protocol: c.protocol,
 		request:  &c.request,
@@ -380,6 +384,9 @@ func (c *Conn) Prepare(query string) (driver.Stmt, error) {
 
 // ExecContext is an optional interface that may be implemented by a Conn.
 func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	ctx, span := tracing.Start(ctx, "dqlite.driver.ExecContext", query)
+	defer span.End()
+
 	if int64(len(args)) > math.MaxUint32 {
 		return nil, driverError(c.log, fmt.Errorf("too many parameters (%d)", len(args)))
 	} else if len(args) > math.MaxUint8 {
@@ -416,6 +423,9 @@ func (c *Conn) Query(query string, args []driver.Value) (driver.Rows, error) {
 
 // QueryContext is an optional interface that may be implemented by a Conn.
 func (c *Conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	ctx, span := tracing.Start(ctx, "dqlite.driver.QueryContext", query)
+	defer span.End()
+
 	if int64(len(args)) > math.MaxUint32 {
 		return nil, driverError(c.log, fmt.Errorf("too many parameters (%d)", len(args)))
 	} else if len(args) > math.MaxUint8 {
@@ -576,6 +586,9 @@ func (s *Stmt) NumInput() int {
 //
 // ExecContext must honor the context timeout and return when it is canceled.
 func (s *Stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	ctx, span := tracing.Start(ctx, "dqlite.driver.Stmt.ExecContext", s.sql)
+	defer span.End()
+
 	if int64(len(args)) > math.MaxUint32 {
 		return nil, driverError(s.log, fmt.Errorf("too many parameters (%d)", len(args)))
 	} else if len(args) > math.MaxUint8 {
@@ -615,6 +628,9 @@ func (s *Stmt) Exec(args []driver.Value) (driver.Result, error) {
 //
 // QueryContext must honor the context timeout and return when it is canceled.
 func (s *Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	ctx, span := tracing.Start(ctx, "dqlite.driver.Stmt.QueryContext", s.sql)
+	defer span.End()
+
 	if int64(len(args)) > math.MaxUint32 {
 		return nil, driverError(s.log, fmt.Errorf("too many parameters (%d)", len(args)))
 	} else if len(args) > math.MaxUint8 {

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -1,0 +1,82 @@
+package tracing
+
+import "context"
+
+type contextKey string
+
+const (
+	traceContextKey contextKey = "trace"
+)
+
+// TracerFromContext returns a tracer from the context. If no tracer is found,
+// an empty tracer is returned.
+func TracerFromContext(ctx context.Context) Tracer {
+	value := ctx.Value(traceContextKey)
+	if value == nil {
+		return noopTracer{}
+	}
+	tracer, ok := value.(Tracer)
+	if !ok {
+		return noopTracer{}
+	}
+	return tracer
+}
+
+// WithTracer returns a new context with the given tracer.
+func WithTracer(ctx context.Context, tracer Tracer) context.Context {
+	if tracer == nil {
+		tracer = noopTracer{}
+	}
+	return context.WithValue(ctx, traceContextKey, tracer)
+}
+
+// Start returns a new context with the given trace.
+func Start(ctx context.Context, name, query string) (context.Context, Span) {
+	// Tracer is always guaranteed to be returned here. If there is no tracer
+	// available it will return a noop tracer.
+	tracer := TracerFromContext(ctx)
+	return tracer.Start(ctx, name, query)
+}
+
+// Tracer is the interface that all tracers must implement.
+type Tracer interface {
+	// Start creates a span and a context.Context containing the newly-created
+	// span.
+	//
+	// If the context.Context provided in `ctx` contains a Span then the
+	// newly-created Span will be a child of that span, otherwise it will be a
+	// root span.
+	//
+	// Any Span that is created MUST also be ended. This is the responsibility
+	// of the user. Implementations of this API may leak memory or other
+	// resources if Spans are not ended.
+	Start(context.Context, string, string) (context.Context, Span)
+}
+
+// Span is the individual component of a trace. It represents a single named
+// and timed operation of a workflow that is traced. A Tracer is used to
+// create a Span and it is then up to the operation the Span represents to
+// properly end the Span when the operation itself ends.
+type Span interface {
+	// End completes the Span. The Span is considered complete and ready to be
+	// delivered through the rest of the telemetry pipeline after this method
+	// is called. Therefore, updates to the Span are not allowed after this
+	// method has been called.
+	End()
+}
+
+// noopTracer is a tracer that does nothing.
+type noopTracer struct{}
+
+func (noopTracer) Start(ctx context.Context, name, query string) (context.Context, Span) {
+	return ctx, noopSpan{}
+}
+
+// noopSpan is a span that does nothing.
+type noopSpan struct{}
+
+// End completes the Span. The Span is considered complete and ready to be
+// delivered through the rest of the telemetry pipeline after this method
+// is called. Therefore, updates to the Span are not allowed after this
+// method has been called.
+func (noopSpan) End() {}


### PR DESCRIPTION
To aid with debugging and development, the following implements the ability to trace requests to the driver. This includes adding the current SQL from conn methods ExecContext or QueryContext, and also adding the stmt ExecContext and QueryContext. Unfortunately, we can't trace every method as the go driver library doesn't allow passing a context to Commit or Rollback.

This is the lightest touch with adding tracing. The tracing code does not require any external dependencies, as this retrieves a Tracer from the passed-in context. As long as the Tracer conforms to the tracing.Tracer interface then a trace can be performed.

There will always be a Tracer if one isn't located on the context.

Potentially, this could supersede the current tracing implementation and remove the need to have a tracing log.

## Example

Currently, the Juju project is starting to implement OpenTelemetry to better understand requests within the system. As the dqlite project is a big part of Juju it would be good if we could see what's happening within the go-dqlite library. I've added a work-in-progress [tempo](https://grafana.com/oss/tempo/) screenshot to show what's available with this PR and what information we might start to gather.

![Screenshot from 2023-09-22 22-02-24](https://github.com/canonical/go-dqlite/assets/2562584/f022fdd7-c19f-4ca0-b63f-3019b742d8fd)
