### PR TITLE
internal/bindings: Fall back if dqlite_node_set_auto_recovery is missing

### DIFF
--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -62,6 +62,16 @@ static void setInfo(dqlite_node_info_ext *infos, unsigned i, dqlite_node_id id,
 	info->dqlite_role = role;
 }
 
+__attribute__((weak))
+int dqlite_node_set_auto_recovery(dqlite_node *t, bool on);
+
+static int setAutoRecovery(dqlite_node *t, bool on) {
+	if (dqlite_node_set_auto_recovery == NULL) {
+		return DQLITE_ERROR;
+	}
+	return dqlite_node_set_auto_recovery(t, on);
+}
+
 */
 import "C"
 import (
@@ -185,7 +195,7 @@ func (s *Node) EnableDiskMode() error {
 
 func (s *Node) SetAutoRecovery(on bool) error {
 	server := (*C.dqlite_node)(unsafe.Pointer(s.node))
-	if rc := C.dqlite_node_set_auto_recovery(server, C.bool(on)); rc != 0 {
+	if rc := C.setAutoRecovery(server, C.bool(on)); rc != 0 {
 		return fmt.Errorf("failed to set auto-recovery behavior")
 	}
 	return nil

--- a/internal/bindings/server_test.go
+++ b/internal/bindings/server_test.go
@@ -103,6 +103,17 @@ func TestNode_Leader(t *testing.T) {
 	require.NoError(t, conn.Close())
 }
 
+func TestNode_Autorecovery(t *testing.T) {
+	dir, cleanup := newDir(t)
+	defer cleanup()
+
+	server, err := bindings.NewNode(context.Background(), 1, "1", dir)
+	require.NoError(t, err)
+	defer server.Close()
+
+	err = server.SetAutoRecovery(false)
+}
+
 // func TestNode_Heartbeat(t *testing.T) {
 // 	server, cleanup := newNode(t)
 // 	defer cleanup()

--- a/node.go
+++ b/node.go
@@ -145,9 +145,11 @@ func New(id uint64, address string, dir string, options ...Option) (*Node, error
 			return nil, err
 		}
 	}
-	if err := server.SetAutoRecovery(o.AutoRecovery); err != nil {
-		cancel()
-		return nil, err
+	if !o.AutoRecovery {
+		if err := server.SetAutoRecovery(false); err != nil {
+			cancel()
+			return nil, err
+		}
 	}
 
 	s := &Node{


### PR DESCRIPTION
This uses weak linkage to implement a graceful fallback at run time when the dqlite_node_set_auto_recovery symbol is not provided by libdqlite. With this merged, we can cut a release of go-dqlite without increasing the minimum supported libdqlite version.

Signed-off-by: Cole Miller <cole.miller@canonical.com>