### PR TITLE
github: Don't install libraft-dev package

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         sudo add-apt-repository ppa:dqlite/dev -y
         sudo apt update
-        sudo apt install -y golint libsqlite3-dev libuv1-dev liblz4-dev libraft-dev libdqlite-dev
+        sudo apt install -y golint libsqlite3-dev libuv1-dev liblz4-dev libdqlite-dev
         go get github.com/go-playground/overalls
 
     - name: Build & Test


### PR DESCRIPTION
Raft is a dependency of the libdqlite-dev package, and mentioning it by name here causes problems since we started using the name `raft-canonical` (etc.) in the PPA.

Signed-off-by: Cole Miller <cole.miller@canonical.com>