### PR TITLE
set client timeout in dqlite demo

### DIFF
--- a/cmd/dqlite/dqlite.go
+++ b/cmd/dqlite/dqlite.go
@@ -11,20 +11,20 @@ import (
 	"strings"
 	"time"
 
+	"github.com/peterh/liner"
+	"github.com/spf13/cobra"
+
 	"github.com/canonical/go-dqlite/app"
 	"github.com/canonical/go-dqlite/client"
 	"github.com/canonical/go-dqlite/internal/shell"
-	"github.com/peterh/liner"
-	"github.com/spf13/cobra"
 )
-
-const queryTimeout = time.Second * 2
 
 func main() {
 	var crt string
 	var key string
 	var servers *[]string
 	var format string
+	var timeoutMsec uint
 
 	cmd := &cobra.Command{
 		Use:   "dqlite -s <servers> <database> [command]",
@@ -94,7 +94,7 @@ func main() {
 
 			if len(args) > 1 {
 				for _, input := range strings.Split(args[1], ";") {
-					ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutMsec)*time.Millisecond)
 					defer cancel()
 					result, err := sh.Process(ctx, input)
 					if err != nil {
@@ -118,7 +118,7 @@ func main() {
 					return err
 				}
 
-				ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+				ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutMsec)*time.Millisecond)
 				defer cancel()
 				result, err := sh.Process(ctx, input)
 				if err != nil {
@@ -140,6 +140,7 @@ func main() {
 	flags.StringVarP(&crt, "cert", "c", "", "public TLS cert")
 	flags.StringVarP(&key, "key", "k", "", "private TLS key")
 	flags.StringVarP(&format, "format", "f", "tabular", "output format (tabular, json)")
+	flags.UintVar(&timeoutMsec, "timeout", 2000, "timeout of each request (msec)")
 
 	cmd.MarkFlagRequired("servers")
 

--- a/cmd/dqlite/dqlite.go
+++ b/cmd/dqlite/dqlite.go
@@ -18,6 +18,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const queryTimeout = time.Second * 2
+
 func main() {
 	var crt string
 	var key string
@@ -92,7 +94,9 @@ func main() {
 
 			if len(args) > 1 {
 				for _, input := range strings.Split(args[1], ";") {
-					result, err := sh.Process(context.Background(), input)
+					ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+					defer cancel()
+					result, err := sh.Process(ctx, input)
 					if err != nil {
 						return err
 					} else if result != "" {
@@ -114,7 +118,7 @@ func main() {
 					return err
 				}
 
-				ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+				ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 				defer cancel()
 				result, err := sh.Process(ctx, input)
 				if err != nil {

--- a/cmd/dqlite/dqlite.go
+++ b/cmd/dqlite/dqlite.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/canonical/go-dqlite/app"
 	"github.com/canonical/go-dqlite/client"
@@ -113,7 +114,8 @@ func main() {
 					return err
 				}
 
-				result, err := sh.Process(context.Background(), input)
+				ctx, _ := context.WithTimeout(context.Background(), time.Second*2)
+				result, err := sh.Process(ctx, input)
 				if err != nil {
 					fmt.Println("Error: ", err)
 				} else {

--- a/cmd/dqlite/dqlite.go
+++ b/cmd/dqlite/dqlite.go
@@ -114,7 +114,8 @@ func main() {
 					return err
 				}
 
-				ctx, _ := context.WithTimeout(context.Background(), time.Second*2)
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+				defer cancel()
 				result, err := sh.Process(ctx, input)
 				if err != nil {
 					fmt.Println("Error: ", err)


### PR DESCRIPTION
Change the policy from retrying indefinitely to having a timeout to improve user experience. The timeout is configurable via a CLI flag (`--timeout`) and defaults to 2s.