### PR TITLE
Improve Message.getBlob performance

### DIFF
--- a/internal/protocol/message_internal_test.go
+++ b/internal/protocol/message_internal_test.go
@@ -302,6 +302,31 @@ func TestMessage_getBlob(t *testing.T) {
 	}
 }
 
+func BenchmarkMessage_getBlob(b *testing.B) {
+	makeBlob := func(size int) []byte {
+		blob := make([]byte, size)
+		for i := range blob {
+			blob[i] = byte(i)
+		}
+		return blob
+	}
+
+	for _, size := range []int{16, 64, 256, 1024, 4096, 8096} {
+		b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+			message := Message{}
+			message.Init(size + 16)
+
+			message.putBlob(makeBlob(size))
+			message.putHeader(0, 0)
+
+			for i := 0; i < b.N; i++ {
+				message.Rewind()
+				_ = message.getBlob()
+			}
+		})
+	}
+}
+
 // The overflowing string ends exactly at word boundary.
 func TestMessage_getString_Overflow_WordBoundary(t *testing.T) {
 	message := Message{}


### PR DESCRIPTION
While gathering the first profiles for Kine, I noticed a big performance footprint in `Message.getBlob`. The fix is trivial and I added a benchmark to make sure it actually is useful.


I'm attaching the [before](https://github.com/user-attachments/files/15514156/before.txt) and [after](https://github.com/user-attachments/files/15514157/after.txt) output for `go test -benchmem -run=^$ -bench BenchmarkMessage_getBlob -count 10` run on my machine.

The `benchstat` output shows promising results (and the function disappears from my flamegraph):

```
goos: linux
goarch: amd64
pkg: github.com/canonical/go-dqlite/internal/protocol
cpu: Intel(R) Core(TM) i5-6300U CPU @ 2.40GHz
                       │  before.txt   │              after.txt               │
                       │    sec/op     │    sec/op     vs base                │
Message_getBlob/16-4     172.95n ± 11%   49.62n ± 29%  -71.31% (p=0.000 n=10)
Message_getBlob/64-4     524.70n ±  3%   65.54n ±  4%  -87.51% (p=0.000 n=10)
Message_getBlob/256-4    1979.5n ±  6%   136.2n ± 27%  -93.12% (p=0.000 n=10)
Message_getBlob/1024-4   7661.5n ±  1%   340.8n ±  8%  -95.55% (p=0.000 n=10)
Message_getBlob/4096-4   30.211µ ±  0%   1.207µ ±  3%  -96.01% (p=0.000 n=10)
Message_getBlob/8096-4   58.492µ ±  2%   2.333µ ±  2%  -96.01% (p=0.000 n=10)
geomean                   3.667µ         274.2n        -92.52%

                       │  before.txt  │               after.txt               │
                       │     B/op     │     B/op      vs base                 │
Message_getBlob/16-4       16.00 ± 0%     16.00 ± 0%       ~ (p=1.000 n=10) ¹
Message_getBlob/64-4       64.00 ± 0%     64.00 ± 0%       ~ (p=1.000 n=10) ¹
Message_getBlob/256-4      256.0 ± 0%     256.0 ± 0%       ~ (p=1.000 n=10) ¹
Message_getBlob/1024-4   1.000Ki ± 0%   1.000Ki ± 0%       ~ (p=1.000 n=10) ¹
Message_getBlob/4096-4   4.000Ki ± 0%   4.000Ki ± 0%       ~ (p=1.000 n=10) ¹
Message_getBlob/8096-4   8.000Ki ± 0%   8.000Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                    456.1          456.1       +0.00%
¹ all samples are equal
[after.txt](https://github.com/user-attachments/files/15514148/after.txt)
[before.txt](https://github.com/user-attachments/files/15514149/before.txt)

                       │ before.txt │              after.txt              │
                       │ allocs/op  │ allocs/op   vs base                 │
Message_getBlob/16-4     1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Message_getBlob/64-4     1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Message_getBlob/256-4    1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Message_getBlob/1024-4   1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Message_getBlob/4096-4   1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Message_getBlob/8096-4   1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                  1.000        1.000       +0.00%
¹ all samples are equal
```

