### PR TITLE
Hook into continual dqlite role probes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -595,6 +595,19 @@ func (a *App) run(ctx context.Context, options *options, join bool) {
 			if err := a.maybeAdjustRoles(ctx, cli); err != nil {
 				a.warn("adjust roles: %v", err)
 			}
+
+			leader, err := cli.Leader(ctx)
+			if err != nil {
+				a.error("fetch leader info: %v", err)
+				cli.Close()
+				continue
+			}
+
+			err = options.OnRolesAdjustment(*leader, servers)
+			if err != nil {
+				a.warn("roles adjustment hook: %v", err)
+			}
+
 			cli.Close()
 		}
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -303,7 +303,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 		}()
 	}
 
-	go app.run(ctx, o.RolesAdjustmentFrequency, joinFileExists)
+	go app.run(ctx, o, joinFileExists)
 
 	return app, nil
 }
@@ -525,7 +525,7 @@ func (a *App) proxy() {
 
 // Run background tasks. The join flag is true if the node is a brand new one
 // and should join the cluster.
-func (a *App) run(ctx context.Context, frequency time.Duration, join bool) {
+func (a *App) run(ctx context.Context, options *options, join bool) {
 	defer close(a.runCh)
 
 	delay := time.Duration(0)
@@ -584,7 +584,7 @@ func (a *App) run(ctx context.Context, frequency time.Duration, join bool) {
 					continue
 				}
 				ready = true
-				delay = frequency
+				delay = options.RolesAdjustmentFrequency
 				close(a.readyCh)
 				cli.Close()
 				continue

--- a/app/options.go
+++ b/app/options.go
@@ -139,6 +139,15 @@ func WithRolesAdjustmentFrequency(frequency time.Duration) Option {
 	}
 }
 
+// WithRolesAdjustmentHook will be run each time the roles are adjusted, as
+// controlled by WithRolesAdjustmentFrequency. Provides the current raft leader information
+// as well as the most up to date list of cluster members and their roles.
+func WithRolesAdjustmentHook(hook func(leader client.NodeInfo, cluster []client.NodeInfo) error) Option {
+	return func(o *options) {
+		o.OnRolesAdjustment = hook
+	}
+}
+
 // WithLogFunc sets a custom log function.
 func WithLogFunc(log client.LogFunc) Option {
 	return func(options *options) {
@@ -223,6 +232,7 @@ type options struct {
 	Voters                   int
 	StandBys                 int
 	RolesAdjustmentFrequency time.Duration
+	OnRolesAdjustment        func(client.NodeInfo, []client.NodeInfo) error
 	FailureDomain            uint64
 	NetworkLatency           time.Duration
 	UnixSocket               string
@@ -239,6 +249,7 @@ func defaultOptions() *options {
 		Voters:                   3,
 		StandBys:                 3,
 		RolesAdjustmentFrequency: 30 * time.Second,
+		OnRolesAdjustment:        func(client.NodeInfo, []client.NodeInfo) error { return nil },
 		DiskMode:                 false, // Be explicit about not enabling disk-mode by default.
 		AutoRecovery:             true,
 	}


### PR DESCRIPTION
After starting the `go-dqlite` `App`, it continually checks for role adjustments and updates the local store of nodes. The frequency of this check can be managed by `WithRolesAdjustmentFrequency`. 

From the perspective of a project using `go-dqlite` it would be very useful to hook into this continual check to piggy-back heartbeats off of, or generally keep an up-to-date record of what dqlite sees.

To that end, this PR introduces the `WithRolesAdjustmentHook` option to `app.App` which is run after attempting a role adjustment. It will provide a client to the current dqlite leader, as well as a list of the most recently updated dqlite nodes so that the project using `go-dqlite` can update its own state without having to send further requests over the network to determine this information.