### PR TITLE
Use range loop instead of endless loop

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -275,8 +275,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 
 	} else if o.Conn != nil {
 		go func() {
-			for {
-				remote := <-o.Conn.acceptCh
+			for remote := range o.Conn.acceptCh {
 
 				// keep forward compatible
 				_, isTcp := remote.(*net.TCPConn)


### PR DESCRIPTION
This PR uses range loop instead of infinite loop + recv from channel as it is difficult during application tear-down to synchronize between application shutdown and listener closing. If for some reason the `acceptChan` is closed while the goroutine is still waiting, the received connection is `nil` and makes the code panic.

Using range loop over the channel solves the problem, makes the code more robust and (arguably) more idiomatic.