### PR TITLE
Add a wrapper for dqlite_node_describe_last_entry

### DIFF
--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -258,6 +258,16 @@ func (s *Node) RecoverExt(cluster []protocol.NodeInfo) error {
 	return nil
 }
 
+func (s *Node) DescribeLastEntry() (uint64, uint64, error) {
+	server := (*C.dqlite_node)(unsafe.Pointer(s.node))
+	index := C.uint64_t(0)
+	term := C.uint64_t(0)
+	if rc := C.dqlite_node_describe_last_entry(server, &index, &term); rc != 0 {
+		return 0, 0, fmt.Errorf("dqlite_node_describe_last_entry failed with error code %d", rc)
+	}
+	return uint64(index), uint64(term), nil
+}
+
 // GenerateID generates a unique ID for a server.
 func GenerateID(address string) uint64 {
 	caddress := C.CString(address)

--- a/node.go
+++ b/node.go
@@ -269,7 +269,7 @@ func ReconfigureMembershipExt(dir string, cluster []NodeInfo) error {
 // of two LastEntryInfo values is equivalent to asking whether the log of `x`
 // is more up to date than the log of `y`.
 type LastEntryInfo struct {
-	term, index uint64
+	Term, Index uint64
 }
 
 // Read information about the last entry in the raft persistent log from a
@@ -290,7 +290,7 @@ func ReadLastEntryInfo(dir string) (LastEntryInfo, error) {
 	if err != nil {
 		return LastEntryInfo{}, err
 	}
-	return LastEntryInfo{index, term}, nil
+	return LastEntryInfo{term, index}, nil
 }
 
 // Create a options object with sane defaults.

--- a/node.go
+++ b/node.go
@@ -283,7 +283,9 @@ func ReadLastEntryInfo(dir string) (LastEntryInfo, error) {
 		return LastEntryInfo{}, err
 	}
 	defer server.Close()
-	if err = server.SetAutoRecovery(false)
+	if err = server.SetAutoRecovery(false); err != nil {
+		return LastEntryInfo{}, err
+	}
 	index, term, err := server.DescribeLastEntry()
 	if err != nil {
 		return LastEntryInfo{}, err

--- a/node.go
+++ b/node.go
@@ -263,7 +263,8 @@ func ReconfigureMembershipExt(dir string, cluster []NodeInfo) error {
 	return server.RecoverExt(cluster)
 }
 
-// Information about the last entry in the persistent raft log of a node.
+// LastEntryInfo holds information about the last entry in the persistent raft
+// log of a node.
 //
 // The order of fields is significant and ensures that the comparison `x > y`
 // of two LastEntryInfo values is equivalent to asking whether the log of `x`
@@ -272,8 +273,8 @@ type LastEntryInfo struct {
 	Term, Index uint64
 }
 
-// Read information about the last entry in the raft persistent log from a
-// node's data directory.
+// ReadLastEntryInfo reads information about the last entry in the raft
+// persistent log from a node's data directory.
 //
 // This is a non-destructive operation, but is not read-only, since it has the
 // side effect of renaming raft open segment files to closed segment files.

--- a/node_test.go
+++ b/node_test.go
@@ -1,0 +1,36 @@
+package dqlite_test
+
+import (
+	"fmt"
+	"sort"
+
+	dqlite "github.com/canonical/go-dqlite"
+)
+
+type infoSorter []dqlite.LastEntryInfo
+
+func (is infoSorter) Len() int {
+	return len(is)
+}
+
+func (is infoSorter) Less(i, j int) bool {
+	return is[i].Before(is[j])
+}
+
+func (is infoSorter) Swap(i, j int) {
+	is[i], is[j] = is[j], is[i]
+}
+
+func ExampleLastEntryInfo() {
+	infos := []dqlite.LastEntryInfo{
+		{Term: 1, Index: 2},
+		{Term: 2, Index: 2},
+		{Term: 1, Index: 1},
+		{Term: 2, Index: 1},
+	}
+	sort.Sort(infoSorter(infos))
+	fmt.Println(infos)
+	// Output:
+	// [{1 1} {1 2} {2 1} {2 2}]
+
+}


### PR DESCRIPTION
Closes #299. CI will fail until the dqlite PR merges, and we'll need to either bump the minimum supported libdqlite version or add a shim to support older dqlite versions that lack this function.

Signed-off-by: Cole Miller <cole.miller@canonical.com>