### PR TITLE
Propagate dqlite_node_recover_ext errors

### DIFF
--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -252,7 +252,8 @@ func (s *Node) RecoverExt(cluster []protocol.NodeInfo) error {
 		C.setInfo(infos, C.unsigned(i), cid, caddress, crole)
 	}
 	if rc := C.dqlite_node_recover_ext(server, infos, n); rc != 0 {
-		return fmt.Errorf("recover failed with error code %d", rc)
+		errmsg := C.GoString(C.dqlite_node_errmsg(server))
+		return fmt.Errorf("recover failed with error code %d, error details: %s", rc, errmsg)
 	}
 	return nil
 }


### PR DESCRIPTION
This commit ensures that the dqlite recovery error messages are propagated by go-dqlite.