### PR TITLE
CI cleanups

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,8 @@ jobs:
       uses: dominikh/staticcheck-action@v1
       with:
         version: '2024.1.1'
-        install-go: false
+        # staticcheck doesn't build with our minimum supported Go version.
+        #install-go: false
         build-tags: libsqlite3
 
     - name: Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,21 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 1.13.x
-          - 1.14.x
-          - 1.15.x
-          - 1.16.x
-          - 1.17.x
-          - 1.18.x
-          - 1.19.x
-          - 1.20.x
-          - 1.21.x
+          - '1.13'
+          - stable
         os:
           - ubuntu-20.04
           - ubuntu-22.04
-        disk:
-          - 1
-          - 0
+          - ubuntu-24.04
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
@@ -39,11 +30,10 @@ jobs:
         sudo add-apt-repository ppa:dqlite/dev -y
         sudo apt update
         sudo apt install -y golint libsqlite3-dev libuv1-dev liblz4-dev libdqlite-dev
-        go get github.com/go-playground/overalls
 
     - name: Build & Test
       env:
-        CGO_LDFLAGS_ALLOW: "-Wl,-z,now"
+        GO_DQLITE_MULTITHREAD: 1
       run: |
         go version
         go get -t -tags libsqlite3 ./...
@@ -52,9 +42,9 @@ jobs:
         export GO_DQLITE_MULTITHREAD=1
         go test -v -race -coverprofile=coverage.out ./...
         go test -v -tags nosqlite3 ./...
-        VERBOSE=1 DISK=${{ matrix.disk }} ./test/dqlite-demo.sh
-        VERBOSE=1 DISK=${{ matrix.disk }} ./test/roles.sh
-        VERBOSE=1 DISK=${{ matrix.disk }} ./test/recover.sh
+        VERBOSE=1 ./test/dqlite-demo.sh
+        VERBOSE=1 ./test/roles.sh
+        VERBOSE=1 ./test/recover.sh
 
     - name: Coverage
       uses: coverallsapp/github-action@v2
@@ -64,15 +54,13 @@ jobs:
 
     - name: Benchmark
       env:
-        CGO_LDFLAGS_ALLOW: "-Wl,-z,now"
         GO_DQLITE_MULTITHREAD: 1
       run: |
         go install -tags libsqlite3 github.com/canonical/go-dqlite/cmd/dqlite-benchmark
-        diskmode=$(if [ ${{ matrix.disk }} -eq 1 ]; then echo -n "--disk"; fi)
-        dqlite-benchmark --db 127.0.0.1:9001 --driver $diskmode --cluster 127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003 --workload kvreadwrite &
+        dqlite-benchmark --db 127.0.0.1:9001 --driver --cluster 127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003 --workload kvreadwrite &
         masterpid=$!
-        dqlite-benchmark --db 127.0.0.1:9002 $diskmode --join 127.0.0.1:9001 &
-        dqlite-benchmark --db 127.0.0.1:9003 $diskmode --join 127.0.0.1:9001 &
+        dqlite-benchmark --db 127.0.0.1:9002 --join 127.0.0.1:9001 &
+        dqlite-benchmark --db 127.0.0.1:9003 --join 127.0.0.1:9001 &
         wait $masterpid
         echo "Write results:"
         head -n 5 /tmp/dqlite-benchmark/127.0.0.1:9001/results/0-exec-*

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,18 +29,28 @@ jobs:
       run: |
         sudo add-apt-repository ppa:dqlite/dev -y
         sudo apt update
-        sudo apt install -y golint libsqlite3-dev libuv1-dev liblz4-dev libdqlite-dev
+        sudo apt install -y libsqlite3-dev libuv1-dev liblz4-dev libdqlite-dev
 
-    - name: Build & Test
+    - name: Download deps
+      run: |
+        go get -t -tags libsqlite3 ./...
+
+    - name: Go vet
+      run: |
+        go vet -tags libsqlite3 ./...
+
+    - name: Staticcheck
+      uses: dominikh/staticcheck-action@v1
+      with:
+        version: '2024.1.1'
+        install-go: false
+        build-tags: libsqlite3
+
+    - name: Test
       env:
         GO_DQLITE_MULTITHREAD: 1
       run: |
-        go version
-        go get -t -tags libsqlite3 ./...
-        go vet -tags libsqlite3 ./...
-        golint
-        export GO_DQLITE_MULTITHREAD=1
-        go test -v -race -coverprofile=coverage.out ./...
+        go test -v -tags libsqlite3 -race -coverprofile=coverage.out ./...
         go test -v -tags nosqlite3 ./...
         VERBOSE=1 ./test/dqlite-demo.sh
         VERBOSE=1 ./test/roles.sh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,18 +35,6 @@ jobs:
       run: |
         go get -t -tags libsqlite3 ./...
 
-    - name: Go vet
-      run: |
-        go vet -tags libsqlite3 ./...
-
-    - name: Staticcheck
-      uses: dominikh/staticcheck-action@v1
-      with:
-        version: '2024.1.1'
-        # staticcheck doesn't build with our minimum supported Go version.
-        #install-go: false
-        build-tags: libsqlite3
-
     - name: Test
       env:
         GO_DQLITE_MULTITHREAD: 1

--- a/.github/workflows/daily-benchmark.yml
+++ b/.github/workflows/daily-benchmark.yml
@@ -5,13 +5,7 @@ on:
 
 jobs:
   benchmark:
-    strategy:
-      fail-fast: false
-      matrix:
-        disk:
-          - 1
-          - 0
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -19,7 +13,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: stable
 
     - name: Setup dependencies
       run: |
@@ -29,13 +23,11 @@ jobs:
 
     - name: Build & Benchmark
       env:
-        CGO_LDFLAGS_ALLOW: "-Wl,-z,now"
         GO_DQLITE_MULTITHREAD: 1
       run: |
         go get -t -tags libsqlite3 ./...
         go install -tags libsqlite3 github.com/canonical/go-dqlite/cmd/dqlite-benchmark
-        diskmode=$(if [ ${{ matrix.disk }} -eq 1 ]; then echo -n "--disk"; fi)
-        dqlite-benchmark --db 127.0.0.1:9001 --duration 3600 --driver $diskmode --cluster 127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003 --workload kvreadwrite &
+        dqlite-benchmark --db 127.0.0.1:9001 --duration 3600 --driver --cluster 127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003 --workload kvreadwrite &
         masterpid=$!
         dqlite-benchmark --db 127.0.0.1:9002 --join 127.0.0.1:9001 &
         dqlite-benchmark --db 127.0.0.1:9003 --join 127.0.0.1:9001 &

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,19 @@
+name: Static checks
+on:
+  - push
+  - pull_request
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+      - name: Go vet
+        run: |
+          go vet -tags libsqlite3 ./...
+      - uses: dominikh/staticcheck-action@v1
+        with:
+          version: '2024.1.1'
+          build-tags: libsqlite3
+          install-go: false

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -9,6 +9,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Install libdqlite
+        run: |
+          sudo add-apt-repository ppa:dqlite/dev -y
+          sudo apt update
+          sudo apt install -y libdqlite-dev
       - name: Go vet
         run: |
           go vet -tags libsqlite3 ./...

--- a/app/app.go
+++ b/app/app.go
@@ -253,8 +253,8 @@ func New(dir string, options ...Option) (app *App, err error) {
 		tls:             o.TLS,
 		ctx:             ctx,
 		stop:            stop,
-		runCh:           make(chan struct{}, 0),
-		readyCh:         make(chan struct{}, 0),
+		runCh:           make(chan struct{}),
+		readyCh:         make(chan struct{}),
 		voters:          o.Voters,
 		standbys:        o.StandBys,
 		roles:           RolesConfig{Voters: o.Voters, StandBys: o.StandBys},
@@ -267,7 +267,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 		if err != nil {
 			return nil, fmt.Errorf("listen to %s: %w", info.Address, err)
 		}
-		proxyCh := make(chan struct{}, 0)
+		proxyCh := make(chan struct{})
 
 		app.listener = listener
 		app.proxyCh = proxyCh
@@ -746,6 +746,7 @@ func (a *App) debug(format string, args ...interface{}) {
 	a.log(client.LogDebug, format, args...)
 }
 
+//lint:ignore U1000 not currently used but preserved for consistency
 func (a *App) info(format string, args ...interface{}) {
 	a.log(client.LogInfo, format, args...)
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -361,7 +361,7 @@ func TestHandover_VoterHonorFailureDomain(t *testing.T) {
 	require.NoError(t, err)
 	defer cli.Close()
 
-	cluster, err := cli.Cluster(context.Background())
+	_, err = cli.Cluster(context.Background())
 	require.NoError(t, err)
 
 	require.NoError(t, apps[2].Handover(context.Background()))

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -366,7 +366,7 @@ func TestHandover_VoterHonorFailureDomain(t *testing.T) {
 
 	require.NoError(t, apps[2].Handover(context.Background()))
 
-	cluster, err = cli.Cluster(context.Background())
+	cluster, err := cli.Cluster(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, client.Voter, cluster[0].Role)

--- a/app/options.go
+++ b/app/options.go
@@ -330,5 +330,5 @@ func defaultLogFunc(l client.LogLevel, format string, a ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf("["+l.String()+"]"+" dqlite: "+format, a...)
-	log.Printf(msg)
+	log.Printf("%s", msg)
 }

--- a/app/proxy.go
+++ b/app/proxy.go
@@ -42,8 +42,8 @@ func proxy(ctx context.Context, remote net.Conn, local net.Conn, config *tls.Con
 		}
 	}
 
-	remoteToLocal := make(chan error, 0)
-	localToRemote := make(chan error, 0)
+	remoteToLocal := make(chan error)
+	localToRemote := make(chan error)
 
 	// Start copying data back and forth until either the client or the
 	// server get closed or hit an error.

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -85,7 +85,7 @@ func (bm *Benchmark) reportFiles() map[string]string {
 		reports := worker.report()
 		for w, report := range reports {
 			file := reportName(i, w)
-			allReports[file] = fmt.Sprintf("%s", report)
+			allReports[file] = report.String()
 		}
 	}
 	return allReports

--- a/client/store_test.go
+++ b/client/store_test.go
@@ -28,6 +28,7 @@ func TestDefaultNodeStore(t *testing.T) {
 	require.NoError(t, err)
 
 	servers, err := store.Get(context.Background())
+	require.NoError(t, err)
 	assert.Equal(t, []client.NodeInfo{
 		{ID: uint64(1), Address: "1.2.3.4:666"},
 		{ID: uint64(1), Address: "5.6.7.8:666"}},
@@ -40,6 +41,7 @@ func TestDefaultNodeStore(t *testing.T) {
 	require.NoError(t, err)
 
 	servers, err = store.Get(context.Background())
+	require.NoError(t, err)
 	assert.Equal(t, []client.NodeInfo{
 		{ID: uint64(1), Address: "1.2.3.4:666"},
 		{ID: uint64(1), Address: "9.9.9.9:666"}},
@@ -53,6 +55,7 @@ func TestDefaultNodeStore(t *testing.T) {
 	assert.EqualError(t, err, "failed to insert server 1.2.3.4:666: UNIQUE constraint failed: servers.address")
 
 	servers, err = store.Get(context.Background())
+	require.NoError(t, err)
 	assert.Equal(t, []client.NodeInfo{
 		{ID: uint64(1), Address: "1.2.3.4:666"},
 		{ID: uint64(1), Address: "9.9.9.9:666"}},

--- a/cmd/dqlite-benchmark/dqlite-benchmark.go
+++ b/cmd/dqlite-benchmark/dqlite-benchmark.go
@@ -87,13 +87,10 @@ func main() {
 				return errors.Wrap(err, "App not ready in time")
 			}
 
-			ch := signalChannel()
 			if !driver {
 				fmt.Println("Benchmark client ready. Send signal to abort or when done.")
-				select {
-				case <-ch:
-					return nil
-				}
+				<-signalChannel()
+				return nil
 			}
 
 			if len(*cluster) == 0 {

--- a/cmd/dqlite-benchmark/dqlite-benchmark.go
+++ b/cmd/dqlite-benchmark/dqlite-benchmark.go
@@ -87,9 +87,10 @@ func main() {
 				return errors.Wrap(err, "App not ready in time")
 			}
 
+			ch := signalChannel()
 			if !driver {
 				fmt.Println("Benchmark client ready. Send signal to abort or when done.")
-				<-signalChannel()
+				<-ch
 				return nil
 			}
 

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -627,7 +627,7 @@ func Test_DescribeLastEntry(t *testing.T) {
 	conn, err := drv.Open("test.db")
 	require.NoError(t, err)
 
-	_, err = conn.(driver.ExecerContext).Exec(`CREATE TABLE test (n INT)`, nil)
+	_, err = conn.(driver.ExecerContext).ExecContext(`CREATE TABLE test (n INT)`, nil)
 	require.NoError(t, err)
 
 	stmt, err := conn.Prepare(`INSERT INTO test(n) VALUES(?)`)

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -627,7 +627,7 @@ func Test_DescribeLastEntry(t *testing.T) {
 	conn, err := drv.Open("test.db")
 	require.NoError(t, err)
 
-	_, err = conn.(driver.ExecerContext).ExecContext(`CREATE TABLE test (n INT)`, nil)
+	_, err = conn.(driver.ExecerContext).ExecContext(context.Background(), `CREATE TABLE test (n INT)`, nil)
 	require.NoError(t, err)
 
 	stmt, err := conn.Prepare(`INSERT INTO test(n) VALUES(?)`)

--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -232,7 +232,7 @@ func (s *Node) Close() {
 
 // Remark that Recover doesn't take the node role into account
 func (s *Node) Recover(cluster []protocol.NodeInfo) error {
-	for i, _ := range cluster {
+	for i := range cluster {
 		cluster[i].Role = protocol.Voter
 	}
 	return s.RecoverExt(cluster)

--- a/internal/bindings/server_test.go
+++ b/internal/bindings/server_test.go
@@ -112,6 +112,7 @@ func TestNode_Autorecovery(t *testing.T) {
 	defer server.Close()
 
 	err = server.SetAutoRecovery(false)
+	require.NoError(t, err)
 }
 
 // func TestNode_Heartbeat(t *testing.T) {

--- a/internal/protocol/errors.go
+++ b/internal/protocol/errors.go
@@ -7,11 +7,7 @@ import (
 // Client errors.
 var (
 	ErrNoAvailableLeader = fmt.Errorf("no available dqlite leader server found")
-	errStop              = fmt.Errorf("connector was stopped")
-	errStaleLeader       = fmt.Errorf("server has lost leadership")
-	errNotClustered      = fmt.Errorf("server is not clustered")
 	errNegativeRead      = fmt.Errorf("reader returned negative count from Read")
-	errMessageEOF        = fmt.Errorf("message eof")
 )
 
 // ErrRequest is returned in case of request failure.

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -336,14 +336,6 @@ func (m *Message) getUint8() uint8 {
 	return b.Bytes[b.Offset]
 }
 
-// Read a 2-byte word from the message body.
-func (m *Message) getUint16() uint16 {
-	b := m.bufferForGet()
-	defer b.Advance(2)
-
-	return binary.LittleEndian.Uint16(b.Bytes[b.Offset:])
-}
-
 // Read a 4-byte word from the message body.
 func (m *Message) getUint32() uint32 {
 	b := m.bufferForGet()

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -131,7 +131,7 @@ func (s *Shell) processCluster(ctx context.Context, line string) (string, error)
 		}
 		var indented bytes.Buffer
 		json.Indent(&indented, data, "", "\t")
-		result = string(indented.Bytes())
+		result = indented.String()
 	}
 
 	return result, nil
@@ -205,7 +205,7 @@ func (s *Shell) processDescribe(ctx context.Context, line string) (string, error
 		}
 		var indented bytes.Buffer
 		json.Indent(&indented, data, "", "\t")
-		result = string(indented.Bytes())
+		result = indented.String()
 	}
 
 	return result, nil
@@ -250,6 +250,7 @@ func (s *Shell) processDump(ctx context.Context, line string) (string, error) {
 func (s *Shell) processReconfigure(ctx context.Context, line string) (string, error) {
 	parts := strings.Split(line, " ")
 	if len(parts) != 3 {
+		//lint:ignore ST1005 intentional long prosy error message
 		return "NOK", fmt.Errorf("bad command format, should be: .reconfigure <dir> <clusteryaml>\n" +
 			"Args:\n" +
 			"\tdir - Directory of node with up to date data\n" +
@@ -385,25 +386,4 @@ func (s *Shell) processQuery(ctx context.Context, line string) (string, error) {
 	}
 
 	return strings.TrimRight(sb.String(), "\n"), nil
-}
-
-func (s *Shell) processExec(ctx context.Context, line string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-
-	if _, err := tx.Exec(line); err != nil {
-		err = fmt.Errorf("exec: %w", err)
-		if rbErr := tx.Rollback(); rbErr != nil {
-			return fmt.Errorf("unable to rollback: %v", err)
-		}
-		return err
-	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit: %w", err)
-	}
-
-	return nil
 }

--- a/node.go
+++ b/node.go
@@ -11,7 +11,6 @@ import (
 
 // Node runs a dqlite node.
 type Node struct {
-	log         client.LogFunc // Logger
 	server      *bindings.Node // Low-level C implementation
 	acceptCh    chan error     // Receives connection handling errors
 	id          uint64


### PR DESCRIPTION
Clean up our CI jobs in various ways:

- Only test on the minimum supported Go version (1.13) and the latest version, instead of every version in between.
- Drop golint (deprecated, not in Noble)
- Remove unused `overalls` install
- Remove references to disk mode
- Split out static analysis into its own job that runs with only one Go version, and add staticcheck
- Fix reports from staticcheck

Signed-off-by: Cole Miller <cole.miller@canonical.com>