### PR TITLE
Enable client session cache for App TLS

### DIFF
--- a/app/tls.go
+++ b/app/tls.go
@@ -96,9 +96,10 @@ func SimpleListenTLSConfig(cert tls.Certificate, pool *x509.CertPool) *tls.Confi
 // A user can modify the returned config to suit their specifig needs.
 func SimpleDialTLSConfig(cert tls.Certificate, pool *x509.CertPool) *tls.Config {
 	config := &tls.Config{
-		MinVersion:   tls.VersionTLS12,
-		RootCAs:      pool,
-		Certificates: []tls.Certificate{cert},
+		MinVersion:         tls.VersionTLS12,
+		RootCAs:            pool,
+		Certificates:       []tls.Certificate{cert},
+		ClientSessionCache: tls.NewLRUClientSessionCache(0),
 	}
 
 	x509cert, err := x509.ParseCertificate(cert.Certificate[0])


### PR DESCRIPTION
According to the [Go docs](https://pkg.go.dev/crypto/tls#Config) for `tls.Config` (comment on the SessionTicketsDisabled field):

> Note that on clients, session ticket support is also disabled if ClientSessionCache is nil.

Before this change, SimpleDialTLSConfig implicitly set that field to nil, so it wasn't taking advantage of session resumption.

Note that this doesn't immediately impact any downstreams unless they are using our SimpleTLSConfig. However, it seems worth doing regardless, since the comments in tls.go suggest that SimpleTLSConfig is intended to take advantage of session resumption. At any rate, the app test suite should be more efficient now.

Thanks @marco6 for suggesting to look into this.

Signed-off-by: Cole Miller <cole.miller@canonical.com>