### PR TITLE
CI: Upgrade upload-artifact and staticcheck versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,7 +68,7 @@ jobs:
         echo "Read results:"
         head -n 5 /tmp/dqlite-benchmark/127.0.0.1:9001/results/0-query-*
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: dqlite-benchmark-${{ matrix.os }}-${{ matrix.go }}
         path: /tmp/dqlite-benchmark/127.0.0.1:9001/results/*

--- a/.github/workflows/daily-benchmark.yml
+++ b/.github/workflows/daily-benchmark.yml
@@ -39,7 +39,7 @@ jobs:
         echo "Read results:"
         head -n 5 /tmp/dqlite-benchmark/127.0.0.1:9001/results/0-query-*
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: dqlite-daily-benchmark
         path: /tmp/dqlite-benchmark/127.0.0.1:9001/results/*

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -21,6 +21,6 @@ jobs:
           go vet -tags libsqlite3 ./...
       - uses: dominikh/staticcheck-action@v1
         with:
-          version: '2024.1.1'
+          version: "2025.1"
           build-tags: libsqlite3
           install-go: false


### PR DESCRIPTION
## Description
Upgrade upload-artifact and staticcheck versions.
See: https://github.com/canonical/go-dqlite/pull/362