### PR TITLE
feat: add bindings for busy timeout parameter

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -197,6 +197,7 @@ func New(dir string, options ...Option) (app *App, err error) {
 		dqlite.WithSnapshotParams(o.SnapshotParams),
 		dqlite.WithDiskMode(o.DiskMode),
 		dqlite.WithAutoRecovery(o.AutoRecovery),
+		dqlite.WithBusyTimeout(o.BusyTimeout.Milliseconds()),
 	)
 	if err != nil {
 		stop()

--- a/app/options.go
+++ b/app/options.go
@@ -224,8 +224,12 @@ func WithAutoRecovery(recovery bool) Option {
 	}
 }
 
-// WithBusyTimeout sets the timeout for how long a database operation
-// will wait for a lock to be released before returning an error (SQLITE_BUSY).
+// WithBusyTimeout sets the timeout for how long a database operation will
+// wait for a lock to be released before returning an error (SQLITE_BUSY),
+// that is the amount of time a writer will wait for others to finish writing
+// on the same database.
+//
+// Readers never wait writers nor readers.
 //
 // The default behavior is to fail immediately.
 func WithBusyTimeout(timeout time.Duration) Option {

--- a/app/options.go
+++ b/app/options.go
@@ -224,6 +224,16 @@ func WithAutoRecovery(recovery bool) Option {
 	}
 }
 
+// WithBusyTimeout sets the timeout for how long a database operation
+// will wait for a lock to be released before returning an error (SQLITE_BUSY).
+//
+// The default behavior is to fail immediately.
+func WithBusyTimeout(timeout time.Duration) Option {
+	return func(options *options) {
+		options.BusyTimeout = timeout
+	}
+}
+
 type tlsSetup struct {
 	Listen *tls.Config
 	Dial   *tls.Config
@@ -247,6 +257,7 @@ type options struct {
 	OnRolesAdjustment        func(client.NodeInfo, []client.NodeInfo) error
 	FailureDomain            uint64
 	NetworkLatency           time.Duration
+	BusyTimeout              time.Duration
 	ConcurrentLeaderConns    *int64
 	UnixSocket               string
 	SnapshotParams           dqlite.SnapshotParams

--- a/internal/bindings/build.go
+++ b/internal/bindings/build.go
@@ -2,9 +2,23 @@ package bindings
 
 /*
 #cgo linux LDFLAGS: -ldqlite
+#include <dqlite.h>
 */
 import "C"
 
 // required dqlite version
-var dqliteMajorVersion int = 1
-var dqliteMinorVersion int = 17
+const DqliteMinSupportedVersion = 1_17_00
+
+var DqliteVersion = int(C.dqlite_version_number())
+
+func versionComponents(version int) (major, minor, revision int) {
+	revision = version % 100
+	version /= 100
+
+	minor = version % 100
+	version /= 100
+
+	major = version
+
+	return major, minor, revision
+}

--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -146,12 +146,12 @@ func init() {
 
 // NewNode creates a new Node instance.
 func NewNode(ctx context.Context, id uint64, address string, dir string) (*Node, error) {
-	requiredVersion := dqliteMajorVersion*100 + dqliteMinorVersion
 	// Remove the patch version, as patch versions should be compatible.
-	runtimeVersion := int(C.dqlite_version_number()) / 100
-	if requiredVersion > runtimeVersion {
+	if DqliteVersion < DqliteMinSupportedVersion {
+		requiredMajor, requiredMinor, _ := versionComponents(DqliteMinSupportedVersion)
+		runtimeMajor, runtimeMinor, _ := versionComponents(DqliteMinSupportedVersion)
 		return nil, fmt.Errorf("version mismatch: required version(%d.%d.x) current version(%d.%d.x)",
-			dqliteMajorVersion, dqliteMinorVersion, runtimeVersion/100, runtimeVersion%100)
+			requiredMajor, requiredMinor, runtimeMajor, runtimeMinor)
 	}
 
 	var server *C.dqlite_node

--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -91,6 +91,20 @@ static int setSnapshotParameters(dqlite_node *n, unsigned snapshot_threshold, un
 	 	return DQLITE_ERROR;
 	}
 }
+
+__attribute__((weak))
+int dqlite_node_set_busy_timeout(dqlite_node *n, unsigned msecs);
+
+static int setBusyTimeout(dqlite_node *n, unsigned msecs) {
+	if (dqlite_node_set_busy_timeout) {
+		return dqlite_node_set_busy_timeout(n, msecs);
+	}
+	if (msecs == 0) {
+		return 0;
+	}
+	return DQLITE_ERROR;
+}
+
 */
 import "C"
 import (
@@ -209,6 +223,15 @@ func (s *Node) SetFailureDomain(code uint64) error {
 	ccode := C.failure_domain_t(code)
 	if rc := C.dqlite_node_set_failure_domain(server, ccode); rc != 0 {
 		return fmt.Errorf("set failure domain: %d", rc)
+	}
+	return nil
+}
+
+func (s *Node) SetBusyTimeout(milliseconds uint64) error {
+	server := (*C.dqlite_node)(unsafe.Pointer(s.node))
+	ctimeout := C.unsigned(milliseconds)
+	if rc := C.setBusyTimeout(server, ctimeout); rc != 0 {
+		return fmt.Errorf("failed to set busy timeout")
 	}
 	return nil
 }

--- a/internal/bindings/server_test.go
+++ b/internal/bindings/server_test.go
@@ -115,6 +115,31 @@ func TestNode_Autorecovery(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestNode_SetBusyTimeout(t *testing.T) {
+	const firstBusyTimeoutVersion = 1_18_02
+
+	dir, cleanup := newDir(t)
+	defer cleanup()
+
+	server, err := bindings.NewNode(context.Background(), 1, "1", dir)
+	require.NoError(t, err)
+	defer server.Close()
+
+	t.Run("no-timeout", func(t *testing.T) {
+		err := server.SetBusyTimeout(0)
+		require.NoError(t, err)
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		err := server.SetBusyTimeout(10)
+		if bindings.DqliteVersion >= firstBusyTimeoutVersion {
+			require.NoError(t, err)
+		} else {
+			require.Error(t, err)
+		}
+	})
+}
+
 // func TestNode_Heartbeat(t *testing.T) {
 // 	server, cleanup := newNode(t)
 // 	defer cleanup()

--- a/node.go
+++ b/node.go
@@ -108,8 +108,12 @@ func WithAutoRecovery(recovery bool) Option {
 	}
 }
 
-// WithBusyTimeout sets the timeout for how long a database operation
-// will wait for a lock to be released before returning an error (SQLITE_BUSY).
+// WithBusyTimeout sets the timeout for how long a database operation will
+// wait for a lock to be released before returning an error (SQLITE_BUSY),
+// that is the amount of time a writer will wait for others to finish writing
+// on the same database.
+//
+// Readers never wait writers nor readers.
 //
 // The default behavior is to fail immediately.
 func WithBusyTimeout(msecs int64) Option {

--- a/node.go
+++ b/node.go
@@ -108,6 +108,16 @@ func WithAutoRecovery(recovery bool) Option {
 	}
 }
 
+// WithBusyTimeout sets the timeout for how long a database operation
+// will wait for a lock to be released before returning an error (SQLITE_BUSY).
+//
+// The default behavior is to fail immediately.
+func WithBusyTimeout(msecs int64) Option {
+	return func(options *options) {
+		options.BusyTimeout = uint64(msecs)
+	}
+}
+
 // New creates a new Node instance.
 func New(id uint64, address string, dir string, options ...Option) (*Node, error) {
 	o := defaultOptions()
@@ -165,6 +175,12 @@ func New(id uint64, address string, dir string, options ...Option) (*Node, error
 			return nil, err
 		}
 	}
+	if o.BusyTimeout != 0 {
+		if err := server.SetBusyTimeout(o.BusyTimeout); err != nil {
+			cancel()
+			return nil, err
+		}
+	}
 
 	s := &Node{
 		server:      server,
@@ -202,6 +218,7 @@ type options struct {
 	DialFunc       client.DialFunc
 	BindAddress    string
 	NetworkLatency uint64
+	BusyTimeout    uint64
 	FailureDomain  uint64
 	SnapshotParams bindings.SnapshotParams
 	DiskMode       bool


### PR DESCRIPTION
This PR adds bindings for the new (v1.18.2) server-side busy timeout.