### PR TITLE
feat: support removal of disk mode

### DIFF
--- a/app/options.go
+++ b/app/options.go
@@ -200,10 +200,8 @@ func WithSnapshotParams(params dqlite.SnapshotParams) Option {
 }
 
 // WithDiskMode enables or disables disk-mode.
-// WARNING: This is experimental API, use with caution
-// and prepare for data loss.
-// UNSTABLE: Behavior can change in future.
-// NOT RECOMMENDED for production use-cases, use at own risk.
+// DEPRECATED: this API will always fail on dqlite 1.18.3+ as support for
+// disk mode has been dropped.
 func WithDiskMode(disk bool) Option {
 	return func(options *options) {
 		options.DiskMode = disk
@@ -277,18 +275,18 @@ func isLoopback(iface *net.Interface) bool {
 // see https://stackoverflow.com/a/48519490/3613657
 // Valid IPv4 notations:
 //
-//    "192.168.0.1": basic
-//    "192.168.0.1:80": with port info
+//	"192.168.0.1": basic
+//	"192.168.0.1:80": with port info
 //
 // Valid IPv6 notations:
 //
-//    "::FFFF:C0A8:1": basic
-//    "::FFFF:C0A8:0001": leading zeros
-//    "0000:0000:0000:0000:0000:FFFF:C0A8:1": double colon expanded
-//    "::FFFF:C0A8:1%1": with zone info
-//    "::FFFF:192.168.0.1": IPv4 literal
-//    "[::FFFF:C0A8:1]:80": with port info
-//    "[::FFFF:C0A8:1%1]:80": with zone and port info
+//	"::FFFF:C0A8:1": basic
+//	"::FFFF:C0A8:0001": leading zeros
+//	"0000:0000:0000:0000:0000:FFFF:C0A8:1": double colon expanded
+//	"::FFFF:C0A8:1%1": with zone info
+//	"::FFFF:192.168.0.1": IPv4 literal
+//	"[::FFFF:C0A8:1]:80": with port info
+//	"[::FFFF:C0A8:1%1]:80": with zone and port info
 func isIpV4(ip string) bool {
 	return strings.Count(ip, ":") < 2
 }

--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -91,6 +91,17 @@ static int setSnapshotParameters(dqlite_node *n, unsigned snapshot_threshold, un
 	 	return DQLITE_ERROR;
 	}
 }
+
+__attribute__((weak))
+DQLITE_API int dqlite_node_enable_disk_mode(dqlite_node *n);
+
+static int dqliteNodeEnableDiskMode(dqlite_node *n) {
+	if (dqlite_node_enable_disk_mode) {
+		return dqlite_node_enable_disk_mode(n);
+	}
+	return DQLITE_ERROR;
+}
+
 */
 import "C"
 import (
@@ -215,7 +226,7 @@ func (s *Node) SetFailureDomain(code uint64) error {
 
 func (s *Node) EnableDiskMode() error {
 	server := (*C.dqlite_node)(unsafe.Pointer(s.node))
-	if rc := C.dqlite_node_enable_disk_mode(server); rc != 0 {
+	if rc := C.dqliteNodeEnableDiskMode(server); rc != 0 {
 		return fmt.Errorf("failed to set disk mode")
 	}
 	return nil

--- a/node.go
+++ b/node.go
@@ -84,10 +84,8 @@ func WithSnapshotParams(params SnapshotParams) Option {
 }
 
 // WithDiskMode enables dqlite disk-mode on the node.
-// WARNING: This is experimental API, use with caution
-// and prepare for data loss.
-// UNSTABLE: Behavior can change in future.
-// NOT RECOMMENDED for production use-cases, use at own risk.
+// DEPRECATED: this API will always fail on dqlite 1.18.3+ as support for
+// disk mode has been dropped.
 func WithDiskMode(disk bool) Option {
 	return func(options *options) {
 		options.DiskMode = disk


### PR DESCRIPTION
This PR deprecates `WithDiskMode` options and supports any new version of `dqlite` (likely `1.18.3`) that doesn't have disk mode.