### PR TITLE
chore: fix tests for bind errors in v1.18

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -73,7 +73,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: dqlite-benchmark-${{ matrix.os }}-${{ matrix.go }}
+        name: dqlite-benchmark-${{ matrix.os }}-${{ matrix.go }}-${{ matrix.version }}
         path: /tmp/dqlite-benchmark/127.0.0.1:9001/results/*
 
   finish:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,9 +12,10 @@ jobs:
           - '1.13'
           - stable
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
+          - ubuntu-22.04-arm
+          - ubuntu-24.04-arm
         version:
           - libdqlite1.17
           - libdqlite

--- a/driver/integration_test.go
+++ b/driver/integration_test.go
@@ -101,7 +101,7 @@ func TestIntegration_ConstraintError(t *testing.T) {
 	}
 }
 
-func TestIntegration_ExecBindError(t *testing.T) {
+func TestIntegrationStmt_ExecBindError(t *testing.T) {
 	db, _, cleanup := newDB(t, 1)
 	defer cleanup()
 	defer db.Close()
@@ -112,11 +112,17 @@ func TestIntegration_ExecBindError(t *testing.T) {
 	_, err := db.ExecContext(ctx, "CREATE TABLE test (n INT)")
 	require.NoError(t, err)
 
-	_, err = db.ExecContext(ctx, "INSERT INTO test(n) VALUES(1)", 1)
-	assert.EqualError(t, err, "bind parameters")
+	stmt, err := db.PrepareContext(ctx, "INSERT INTO test(n) VALUES(1)")
+	assert.NoError(t, err)
+
+	_, err = stmt.ExecContext(ctx, 1)
+	require.Error(t, err)
+	if err.Error() != "bind parameters" && err.Error() != "sql: expected 0 arguments, got 1" {
+		t.Error("unexpected error", err)
+	}
 }
 
-func TestIntegration_QueryBindError(t *testing.T) {
+func TestIntegration_StmtQueryBindError(t *testing.T) {
 	db, _, cleanup := newDB(t, 1)
 	defer cleanup()
 	defer db.Close()
@@ -124,8 +130,14 @@ func TestIntegration_QueryBindError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	_, err := db.QueryContext(ctx, "SELECT 1", 1)
-	assert.EqualError(t, err, "bind parameters")
+	stmt, err := db.PrepareContext(ctx, "SELECT 1")
+	assert.NoError(t, err)
+
+	_, err = stmt.QueryContext(ctx, 1)
+	require.Error(t, err)
+	if err.Error() != "bind parameters" && err.Error() != "sql: expected 0 arguments, got 1" {
+		t.Error("unexpected error", err)
+	}
 }
 
 func TestIntegration_LargeQuery(t *testing.T) {


### PR DESCRIPTION
This PR fixes the error checking for binding in version 1.18.