### PR TITLE
Add role eligibility metadata to roles rebalancing

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -236,6 +236,14 @@ func New(dir string, options ...Option) (app *App, err error) {
 		stop()
 		return nil, fmt.Errorf("invalid voters %d: must be an odd number greater than 1", o.Voters)
 	}
+	if o.AllowedRoles != 0 && o.AllowedRoles&client.RoleMaskAll != o.AllowedRoles {
+		stop()
+		return nil, fmt.Errorf("invalid allowed roles mask %d: must be subset of RoleMaskAll", o.AllowedRoles)
+	}
+	if o.AllowedRoles != 0 && o.AllowedRoles&client.RoleMaskSpare == 0 {
+		stop()
+		return nil, fmt.Errorf("invalid allowed roles mask %d: must include RoleMaskSpare", o.AllowedRoles)
+	}
 
 	if runtime.GOOS != "linux" && nodeBindAddress[0] == '@' {
 		// Do not use abstract socket on other platforms and left trim "@"

--- a/app/app.go
+++ b/app/app.go
@@ -763,6 +763,23 @@ func (a *App) makeRolesChanges(nodes []client.NodeInfo) RolesChanges {
 	}
 
 	wg.Wait()
+
+	// libdqlite currently does not emit allowed roles via Describe, so we
+	// inject the local node's configured mask into the probed metadata.
+	if a.options != nil && a.options.AllowedRoles != 0 {
+		mask := a.options.AllowedRoles
+		for node := range state {
+			if node.ID != a.id {
+				continue
+			}
+			if state[node] == nil {
+				state[node] = &client.NodeMetadata{}
+			}
+			state[node].AllowedRoles = &mask
+			break
+		}
+	}
+
 	return RolesChanges{Config: a.roles, State: state}
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -32,6 +32,28 @@ func TestNew_PristineDefault(t *testing.T) {
 	defer cleanup()
 }
 
+func TestNew_InvalidAllowedRolesMask(t *testing.T) {
+	dir, cleanup := newDir(t)
+	defer cleanup()
+
+	_, err := app.New(dir,
+		app.WithAddress("127.0.0.1:9000"),
+		app.WithAllowedRoles(client.RoleMask(1<<7)),
+	)
+	require.Error(t, err)
+}
+
+func TestNew_DisallowSpareRoleMask(t *testing.T) {
+	dir, cleanup := newDir(t)
+	defer cleanup()
+
+	_, err := app.New(dir,
+		app.WithAddress("127.0.0.1:9000"),
+		app.WithAllowedRoles(client.RoleMaskVoter|client.RoleMaskStandBy),
+	)
+	require.Error(t, err)
+}
+
 // Create a pristine joining node.
 func TestNew_PristineJoiner(t *testing.T) {
 	addr1 := "127.0.0.1:9001"

--- a/app/options.go
+++ b/app/options.go
@@ -174,6 +174,21 @@ func WithFailureDomain(code uint64) Option {
 	}
 }
 
+// WithAllowedRoles constrains which roles this node is eligible to assume.
+//
+// This is optional opt-in behavior. If unset (or set to 0), all roles remain allowed.
+//
+// Note: this is enforced locally by go-dqlite during role decisions. libdqlite
+// does not currently emit allowed roles via Describe, so other nodes will not
+// see this mask unless they are similarly configured.
+//
+// A zero mask means "no restriction" (all roles allowed).
+func WithAllowedRoles(mask client.RoleMask) Option {
+	return func(options *options) {
+		options.AllowedRoles = mask
+	}
+}
+
 // WithNetworkLatency sets the average one-way network latency.
 func WithNetworkLatency(latency time.Duration) Option {
 	return func(options *options) {
@@ -265,6 +280,7 @@ type options struct {
 	RolesAdjustmentFrequency time.Duration
 	OnRolesAdjustment        func(client.NodeInfo, []client.NodeInfo) error
 	FailureDomain            uint64
+	AllowedRoles             client.RoleMask
 	NetworkLatency           time.Duration
 	BusyTimeout              time.Duration
 	ConcurrentLeaderConns    *int64

--- a/app/roles.go
+++ b/app/roles.go
@@ -120,6 +120,9 @@ func (c *RolesChanges) Handover(id uint64) (client.NodeRole, []client.NodeInfo) 
 		candidates = append(c.list(client.StandBy, true, nil), candidates...)
 	}
 
+	// Enforce role eligibility for the role being handed over.
+	candidates = c.filterCandidatesByRole(candidates, node.Role)
+
 	if len(candidates) == 0 {
 		// No online node available to be promoted.
 		return -1, nil

--- a/app/roles.go
+++ b/app/roles.go
@@ -147,6 +147,37 @@ func (c *RolesChanges) Adjust(leader uint64) (client.NodeRole, []client.NodeInfo
 	offlineVoters := c.list(client.Voter, false, nil)
 	offlineStandbys := c.list(client.StandBy, false, nil)
 
+	for _, node := range onlineVoters {
+		// Don't demote the leader here; callers should handle leader handover separately.
+		// AllowedRoles are intentionally not enforced on the current leader to avoid
+		// destabilizing leadership; handover should be used to move leadership first.
+		if node.ID == leader {
+			continue
+		}
+		if c.roleAllowed(node, client.Voter) {
+			continue
+		}
+		if c.roleAllowed(node, client.StandBy) {
+			return client.StandBy, []client.NodeInfo{node}
+		}
+
+		return client.Spare, []client.NodeInfo{node}
+	}
+
+	for _, node := range onlineStandbys {
+		if c.roleAllowed(node, client.StandBy) {
+			continue
+		}
+		if c.roleAllowed(node, client.Spare) {
+			return client.Spare, []client.NodeInfo{node}
+		}
+		if c.roleAllowed(node, client.Voter) {
+			return client.Voter, []client.NodeInfo{node}
+		}
+
+		return -1, nil
+	}
+
 	domainsWithVoters := c.failureDomains(onlineVoters)
 	allDomains := c.allFailureDomains()
 
@@ -158,6 +189,7 @@ func (c *RolesChanges) Adjust(leader uint64) (client.NodeRole, []client.NodeInfo
 		// Find nodes in the domains we need to populate
 		candidates := c.list(client.StandBy, true, domainsWithoutVoters)
 		candidates = append(candidates, c.list(client.Spare, true, domainsWithoutVoters)...)
+		candidates = c.filterCandidatesByRole(candidates, client.Voter)
 
 		if len(candidates) > 0 {
 			c.sortCandidates(candidates, domainsWithoutVoters)
@@ -176,6 +208,7 @@ func (c *RolesChanges) Adjust(leader uint64) (client.NodeRole, []client.NodeInfo
 	if n := len(onlineVoters); n < c.Config.Voters {
 		candidates := c.list(client.StandBy, true, nil)
 		candidates = append(candidates, c.list(client.Spare, true, nil)...)
+		candidates = c.filterCandidatesByRole(candidates, client.Voter)
 
 		if len(candidates) == 0 {
 			return -1, nil
@@ -198,18 +231,29 @@ func (c *RolesChanges) Adjust(leader uint64) (client.NodeRole, []client.NodeInfo
 			nodes = append(nodes, node)
 		}
 
+		nodes = c.filterCandidatesByRole(nodes, client.Spare)
+		if len(nodes) == 0 {
+			return -1, nil
+		}
+
 		return client.Spare, c.sortVoterCandidatesToDemote(nodes)
 	}
 
 	// If we have offline voters, let's demote one of them.
 	if n := len(offlineVoters); n > 0 {
-		return client.Spare, offlineVoters
+		candidates := c.filterCandidatesByRole(offlineVoters, client.Spare)
+		if len(candidates) == 0 {
+			return -1, nil
+		}
+
+		return client.Spare, candidates
 	}
 
 	// If we have less online stand-bys than desired, let's try to promote
 	// some other node.
 	if n := len(onlineStandbys); n < c.Config.StandBys {
 		candidates := c.list(client.Spare, true, nil)
+		candidates = c.filterCandidatesByRole(candidates, client.StandBy)
 
 		if len(candidates) == 0 {
 			return -1, nil
@@ -233,12 +277,22 @@ func (c *RolesChanges) Adjust(leader uint64) (client.NodeRole, []client.NodeInfo
 			nodes = append(nodes, node)
 		}
 
+		nodes = c.filterCandidatesByRole(nodes, client.Spare)
+		if len(nodes) == 0 {
+			return -1, nil
+		}
+
 		return client.Spare, nodes
 	}
 
 	// If we have offline stand-bys, let's demote one of them.
 	if n := len(offlineStandbys); n > 0 {
-		return client.Spare, offlineStandbys
+		candidates := c.filterCandidatesByRole(offlineStandbys, client.Spare)
+		if len(candidates) == 0 {
+			return -1, nil
+		}
+
+		return client.Spare, candidates
 	}
 
 	return -1, nil
@@ -388,4 +442,24 @@ func (c *RolesChanges) sortVoterCandidatesToDemote(candidates []client.NodeInfo)
 // Return the metadata of the given node, if any.
 func (c *RolesChanges) metadata(node client.NodeInfo) *client.NodeMetadata {
 	return c.State[node]
+}
+
+func (c *RolesChanges) roleAllowed(node client.NodeInfo, role client.NodeRole) bool {
+	metadata := c.metadata(node)
+	if metadata == nil || metadata.AllowedRoles == nil || *metadata.AllowedRoles == 0 {
+		return true
+	}
+
+	return *metadata.AllowedRoles&client.RoleMaskFor(role) != 0
+}
+
+func (c *RolesChanges) filterCandidatesByRole(candidates []client.NodeInfo, role client.NodeRole) []client.NodeInfo {
+	filtered := make([]client.NodeInfo, 0, len(candidates))
+	for _, node := range candidates {
+		if c.roleAllowed(node, role) {
+			filtered = append(filtered, node)
+		}
+	}
+
+	return filtered
 }

--- a/app/roles.go
+++ b/app/roles.go
@@ -71,6 +71,14 @@ func (c *RolesChanges) Assume(id uint64) client.NodeRole {
 		role = client.Voter
 	}
 
+	// Respect role eligibility for this node.
+	if !c.roleAllowed(*node, role) {
+		if role == client.Voter && c.roleAllowed(*node, client.StandBy) {
+			return client.StandBy
+		}
+		return -1
+	}
+
 	return role
 }
 

--- a/app/roles_test.go
+++ b/app/roles_test.go
@@ -1,0 +1,219 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/canonical/go-dqlite/v3/client"
+)
+
+func roleMask(mask client.RoleMask) *client.RoleMask {
+	return &mask
+}
+
+func TestAdjustDemotesDisallowedVoter(t *testing.T) {
+	node1 := client.NodeInfo{ID: 1, Address: "1", Role: client.Voter}
+	node2 := client.NodeInfo{ID: 2, Address: "2", Role: client.Voter}
+	node3 := client.NodeInfo{ID: 3, Address: "3", Role: client.Voter}
+	node4 := client.NodeInfo{ID: 4, Address: "4", Role: client.Spare}
+
+	state := map[client.NodeInfo]*client.NodeMetadata{
+		node1: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskStandBy | client.RoleMaskSpare)},
+		node2: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node3: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node4: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+	}
+
+	changes := RolesChanges{
+		Config: RolesConfig{Voters: 3, StandBys: 1},
+		State:  state,
+	}
+
+	role, candidates := changes.Adjust(2)
+	if role != client.StandBy {
+		t.Fatalf("expected standby demotion, got %v", role)
+	}
+	if len(candidates) != 1 || candidates[0].ID != node1.ID {
+		t.Fatalf("unexpected candidates: %#v", candidates)
+	}
+}
+
+func TestAdjustDemotesDisallowedStandby(t *testing.T) {
+	node1 := client.NodeInfo{ID: 1, Address: "1", Role: client.Voter}
+	node2 := client.NodeInfo{ID: 2, Address: "2", Role: client.Voter}
+	node3 := client.NodeInfo{ID: 3, Address: "3", Role: client.StandBy}
+
+	state := map[client.NodeInfo]*client.NodeMetadata{
+		node1: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node2: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node3: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskSpare)},
+	}
+
+	changes := RolesChanges{
+		Config: RolesConfig{Voters: 2, StandBys: 1},
+		State:  state,
+	}
+
+	role, candidates := changes.Adjust(1)
+	if role != client.Spare {
+		t.Fatalf("expected spare demotion, got %v", role)
+	}
+	if len(candidates) != 1 || candidates[0].ID != node3.ID {
+		t.Fatalf("unexpected candidates: %#v", candidates)
+	}
+}
+
+func TestAdjustFiltersPromotionByAllowedRoles(t *testing.T) {
+	node1 := client.NodeInfo{ID: 1, Address: "1", Role: client.Voter}
+	node2 := client.NodeInfo{ID: 2, Address: "2", Role: client.Voter}
+	node3 := client.NodeInfo{ID: 3, Address: "3", Role: client.Spare}
+
+	state := map[client.NodeInfo]*client.NodeMetadata{
+		node1: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node2: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node3: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskSpare)},
+	}
+
+	changes := RolesChanges{
+		Config: RolesConfig{Voters: 3, StandBys: 0},
+		State:  state,
+	}
+
+	role, candidates := changes.Adjust(1)
+	if role != -1 || len(candidates) != 0 {
+		t.Fatalf("expected no promotion candidates, got role=%v candidates=%#v", role, candidates)
+	}
+}
+
+func TestAdjustSkipsLeaderEligibility(t *testing.T) {
+	leader := client.NodeInfo{ID: 1, Address: "1", Role: client.Voter}
+	node2 := client.NodeInfo{ID: 2, Address: "2", Role: client.Voter}
+	node3 := client.NodeInfo{ID: 3, Address: "3", Role: client.Voter}
+
+	state := map[client.NodeInfo]*client.NodeMetadata{
+		leader: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskStandBy | client.RoleMaskSpare)},
+		node2:  {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node3:  {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+	}
+
+	changes := RolesChanges{
+		Config: RolesConfig{Voters: 3, StandBys: 0},
+		State:  state,
+	}
+
+	role, candidates := changes.Adjust(leader.ID)
+	if role != -1 || len(candidates) != 0 {
+		t.Fatalf("expected no change for leader with disallowed voter role, got role=%v candidates=%#v", role, candidates)
+	}
+}
+
+func TestAdjustDemotesVoterToSpareWhenClusterTooSmall(t *testing.T) {
+	leader := client.NodeInfo{ID: 1, Address: "1", Role: client.Voter}
+	node2 := client.NodeInfo{ID: 2, Address: "2", Role: client.Voter}
+
+	state := map[client.NodeInfo]*client.NodeMetadata{
+		leader: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node2:  {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskVoter | client.RoleMaskStandBy)},
+	}
+
+	changes := RolesChanges{
+		Config: RolesConfig{Voters: 1, StandBys: 0},
+		State:  state,
+	}
+
+	role, candidates := changes.Adjust(leader.ID)
+	if role != client.Spare {
+		t.Fatalf("expected spare demotion, got %v", role)
+	}
+	if len(candidates) != 1 || candidates[0].ID != node2.ID {
+		t.Fatalf("unexpected candidates: %#v", candidates)
+	}
+}
+
+func TestAdjustSkipsStandbyDemotionWhenSpareDisallowed(t *testing.T) {
+	leader := client.NodeInfo{ID: 1, Address: "1", Role: client.Voter}
+	node2 := client.NodeInfo{ID: 2, Address: "2", Role: client.StandBy}
+
+	state := map[client.NodeInfo]*client.NodeMetadata{
+		leader: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node2:  {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskStandBy)},
+	}
+
+	changes := RolesChanges{
+		Config: RolesConfig{Voters: 1, StandBys: 0},
+		State:  state,
+	}
+
+	role, candidates := changes.Adjust(leader.ID)
+	if role != -1 || len(candidates) != 0 {
+		t.Fatalf("expected no demotion candidates, got role=%v candidates=%#v", role, candidates)
+	}
+}
+
+func TestAssumeFallsBackToStandbyWhenVoterDisallowed(t *testing.T) {
+	node1 := client.NodeInfo{ID: 1, Address: "1", Role: client.Voter}
+	node2 := client.NodeInfo{ID: 2, Address: "2", Role: client.Voter}
+	node3 := client.NodeInfo{ID: 3, Address: "3", Role: client.Spare}
+
+	state := map[client.NodeInfo]*client.NodeMetadata{
+		node1: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node2: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node3: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskStandBy | client.RoleMaskSpare)},
+	}
+
+	changes := RolesChanges{
+		Config: RolesConfig{Voters: 3, StandBys: 1},
+		State:  state,
+	}
+
+	role := changes.Assume(node3.ID)
+	if role != client.StandBy {
+		t.Fatalf("expected standby fallback, got %v", role)
+	}
+}
+
+func TestAssumeReturnsNoChangeWhenAllPromotionsDisallowed(t *testing.T) {
+	node1 := client.NodeInfo{ID: 1, Address: "1", Role: client.Voter}
+	node2 := client.NodeInfo{ID: 2, Address: "2", Role: client.Voter}
+	node3 := client.NodeInfo{ID: 3, Address: "3", Role: client.Spare}
+
+	state := map[client.NodeInfo]*client.NodeMetadata{
+		node1: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node2: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node3: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskSpare)},
+	}
+
+	changes := RolesChanges{
+		Config: RolesConfig{Voters: 3, StandBys: 1},
+		State:  state,
+	}
+
+	role := changes.Assume(node3.ID)
+	if role != -1 {
+		t.Fatalf("expected no role change, got %v", role)
+	}
+}
+
+func TestHandoverFiltersCandidatesByAllowedRoles(t *testing.T) {
+	node1 := client.NodeInfo{ID: 1, Address: "1", Role: client.Voter}
+	node2 := client.NodeInfo{ID: 2, Address: "2", Role: client.StandBy}
+	node3 := client.NodeInfo{ID: 3, Address: "3", Role: client.Spare}
+
+	state := map[client.NodeInfo]*client.NodeMetadata{
+		node1: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskAll)},
+		node2: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskVoter | client.RoleMaskStandBy)},
+		node3: {FailureDomain: 0, AllowedRoles: roleMask(client.RoleMaskSpare)},
+	}
+
+	changes := RolesChanges{
+		Config: RolesConfig{Voters: 3, StandBys: 1},
+		State:  state,
+	}
+
+	role, candidates := changes.Handover(node1.ID)
+	if role != client.Voter {
+		t.Fatalf("expected voter handover, got %v", role)
+	}
+	if len(candidates) != 1 || candidates[0].ID != node2.ID {
+		t.Fatalf("unexpected candidates: %#v", candidates)
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -267,6 +267,10 @@ func (c *Client) Remove(ctx context.Context, id uint64) error {
 type NodeMetadata struct {
 	FailureDomain uint64
 	Weight        uint64
+	// AllowedRoles controls which roles the node can assume.
+	// Nil means the value wasn't provided. A zero value means all roles allowed.
+	// libdqlite does not populate this via Describe; callers can supply it when constructing metadata locally.
+	AllowedRoles *RoleMask
 }
 
 // Describe returns metadata about the node we're connected with.
@@ -282,7 +286,7 @@ func (c *Client) Describe(ctx context.Context) (*NodeMetadata, error) {
 		return nil, err
 	}
 
-	domain, weight, err := protocol.DecodeMetadata(&response)
+	domain, weight, allowedRoles, err := protocol.DecodeMetadata(&response)
 	if err != nil {
 		return nil, err
 	}
@@ -290,6 +294,10 @@ func (c *Client) Describe(ctx context.Context) (*NodeMetadata, error) {
 	metadata := &NodeMetadata{
 		FailureDomain: domain,
 		Weight:        weight,
+	}
+	if allowedRoles != nil {
+		mask := RoleMask(*allowedRoles)
+		metadata.AllowedRoles = &mask
 	}
 
 	return metadata, nil

--- a/client/client.go
+++ b/client/client.go
@@ -265,8 +265,10 @@ func (c *Client) Remove(ctx context.Context, id uint64) error {
 
 // NodeMetadata user-defined node-level metadata.
 type NodeMetadata struct {
+	// FailureDomain identifies a failure domain used during role assignment.
 	FailureDomain uint64
-	Weight        uint64
+	// Weight is used to order candidates within a failure domain (lower is preferred).
+	Weight uint64
 	// AllowedRoles controls which roles the node can assume.
 	// Nil means the value wasn't provided. A zero value means all roles allowed.
 	// libdqlite does not populate this via Describe; callers can supply it when constructing metadata locally.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -102,6 +102,7 @@ func TestClient_Describe(t *testing.T) {
 
 	assert.Equal(t, uint64(0), metadata.FailureDomain)
 	assert.Equal(t, uint64(0), metadata.Weight)
+	assert.Nil(t, metadata.AllowedRoles)
 
 	require.NoError(t, cli.Weight(context.Background(), 123))
 
@@ -110,6 +111,7 @@ func TestClient_Describe(t *testing.T) {
 
 	assert.Equal(t, uint64(0), metadata.FailureDomain)
 	assert.Equal(t, uint64(123), metadata.Weight)
+	assert.Nil(t, metadata.AllowedRoles)
 }
 
 func newNode(t *testing.T) (*dqlite.Node, func()) {

--- a/client/constants.go
+++ b/client/constants.go
@@ -10,3 +10,28 @@ const (
 	StandBy = protocol.StandBy
 	Spare   = protocol.Spare
 )
+
+// RoleMask identifies which roles a node is allowed to hold.
+type RoleMask uint8
+
+const (
+	RoleMaskVoter RoleMask = 1 << iota
+	RoleMaskStandBy
+	RoleMaskSpare
+
+	RoleMaskAll = RoleMaskVoter | RoleMaskStandBy | RoleMaskSpare
+)
+
+// RoleMaskFor returns the mask bit for the given role.
+func RoleMaskFor(role NodeRole) RoleMask {
+	switch role {
+	case Voter:
+		return RoleMaskVoter
+	case StandBy:
+		return RoleMaskStandBy
+	case Spare:
+		return RoleMaskSpare
+	default:
+		return 0
+	}
+}

--- a/internal/protocol/response.go
+++ b/internal/protocol/response.go
@@ -255,7 +255,7 @@ func DecodeFiles(response *Message) (files Files, err error) {
 }
 
 // DecodeMetadata decodes a Metadata response.
-func DecodeMetadata(response *Message) (failureDomain uint64, weight uint64, err error) {
+func DecodeMetadata(response *Message) (failureDomain uint64, weight uint64, allowedRoles *uint64, err error) {
 	mtype, _ := response.getHeader()
 
 	if mtype == ResponseFailure {
@@ -273,6 +273,10 @@ func DecodeMetadata(response *Message) (failureDomain uint64, weight uint64, err
 
 	failureDomain = response.getUint64()
 	weight = response.getUint64()
+	if remaining := int(response.words*messageWordSize) - response.body.Offset; remaining >= messageWordSize {
+		value := response.getUint64()
+		allowedRoles = &value
+	}
 
 	return
 }

--- a/internal/protocol/schema.go
+++ b/internal/protocol/schema.go
@@ -38,4 +38,5 @@ package protocol
 //go:generate ./schema.sh --response Result   result:Result
 //go:generate ./schema.sh --response Rows     rows:Rows
 //go:generate ./schema.sh --response Files    files:Files
-//go:generate ./schema.sh --response Metadata failureDomain:uint64 weight:uint64
+// allowedRoles is optional and currently not emitted by libdqlite.
+//go:generate ./schema.sh --response Metadata failureDomain:uint64 weight:uint64 allowedRoles:uint64?

--- a/internal/protocol/schema.sh
+++ b/internal/protocol/schema.sh
@@ -101,12 +101,21 @@ if [ "$entity" = "--response" ]; then
 	do
 		name=$(echo "$i" | cut -f 1 -d :)
 		type=$(echo "$i" | cut -f 2 -d :)
+		optional="0"
+		if [[ "$type" == *\? ]]; then
+			type=${type%\?}
+			optional="1"
+		fi
 
 		if [ "$name" = "unused" ]; then
 			continue
 		fi
 
-		returns=$(echo "${returns}${name} ${type}, ")
+		if [ "$optional" = "1" ]; then
+			returns=$(echo "${returns}${name} *${type}, ")
+		else
+			returns=$(echo "${returns}${name} ${type}, ")
+		fi
 	done
 
 	cat >> response.go <<EOF
@@ -134,16 +143,31 @@ EOF
 	do
 		name=$(echo "$i" | cut -f 1 -d :)
 		type=$(echo "$i" | cut -f 2 -d :)
-
-		assign=$(echo "${name} = ")
-
-		if [ "$name" = "unused" ]; then
-			assign=$(echo "")
+		optional="0"
+		if [[ "$type" == *\? ]]; then
+			type=${type%\?}
+			optional="1"
 		fi
 
-		cat >> response.go <<EOF
-	${assign}response.get${type^}()
+		if [ "$name" = "unused" ]; then
+			cat >> response.go <<EOF
+	response.get${type^}()
 EOF
+			continue
+		fi
+
+		if [ "$optional" = "1" ]; then
+			cat >> response.go <<EOF
+	if remaining := int(response.words*messageWordSize) - response.body.Offset; remaining >= messageWordSize {
+		value := response.get${type^}()
+		${name} = &value
+	}
+EOF
+		else
+			cat >> response.go <<EOF
+	${name} = response.get${type^}()
+EOF
+		fi
 	done
 
 	cat >> response.go <<EOF


### PR DESCRIPTION
This adds role eligibility hints to go-dqlite and enforces them during role adjustments. Nodes can advertise which roles they are allowed to hold via `AllowedRoles`, and `RolesChanges.Adjust` will demote ineligible voters/standbys while filtering promotion candidates. This enables LXD’s new control plane mode to push eligibility into go‑dqlite’s rebalancing logic so promotion/demotion decisions stay centralized in `RolesChanges.Adjust` instead of being duplicated in LXD. With the new metadata, LXD can mark non‑control‑plane members as spare‑only while control‑plane members remain eligible for voter/standby, keeping enforcement consistent with failure‑domain and weight logic. Includes unit tests for demotion and promotion filtering and godoc updates on metadata fields.

Example usage:

```Go
metadata := &client.NodeMetadata{
	FailureDomain: domains[node.Address],
}

// Default: all roles allowed.
metadata.AllowedRoles = client.RoleMaskAll

if controlPlaneActive {
	roles := memberRoles[node.Address]
	if !slices.Contains(roles, db.ClusterRoleControlPlane) {
    // Non-control-plane members are spare-only when control plane mode is active.
		metadata.AllowedRoles = client.RoleMaskSpare
    }
}
```
