### PR TITLE
Add isolation level support check

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -507,6 +507,10 @@ func (c *Conn) Close() error {
 // true to either set the read-only transaction property if supported or return
 // an error if it is not supported.
 func (c *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if err := validateTxOptions(opts); err != nil {
+		return nil, err
+	}
+
 	if _, err := c.ExecContext(ctx, "BEGIN", nil); err != nil {
 		return nil, err
 	}

--- a/driver/tx_options.go
+++ b/driver/tx_options.go
@@ -1,0 +1,59 @@
+package driver
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+)
+
+// ErrIsolationLevelNotSupported is returned when an unsupported isolation
+// level is requested in BeginTx.
+type ErrIsolationLevelNotSupported struct {
+	Level sql.IsolationLevel
+}
+
+func (e ErrIsolationLevelNotSupported) Error() string {
+	return fmt.Sprintf("isolation level %q is not supported", e.Level)
+}
+
+// ErrReadOnlyNotSupported is returned when a read-only transaction is
+// requested in BeginTx, which dqlite does not support.
+type ErrReadOnlyNotSupported struct{}
+
+func (e ErrReadOnlyNotSupported) Error() string {
+	return "read-only transactions are not supported"
+}
+
+// validateTxOptions checks if the transaction options are supported by dqlite.
+//
+// dqlite (like SQLite) only supports the SERIALIZABLE isolation level
+// (the default), and does not support read-only transactions.
+func validateTxOptions(opts driver.TxOptions) error {
+	return ValidateTxOptions(opts)
+}
+
+// ValidateTxOptions checks if the transaction options are supported by dqlite.
+//
+// dqlite (like SQLite) only supports the SERIALIZABLE isolation level
+// (the default), and does not support read-only transactions.
+//
+// This function is exported for testing purposes.
+func ValidateTxOptions(opts driver.TxOptions) error {
+	// Check isolation level. SQLite/dqlite only supports SERIALIZABLE
+	// (which is the default, represented by sql.LevelDefault or
+	// sql.LevelSerializable).
+	isolation := sql.IsolationLevel(opts.Isolation)
+	switch isolation {
+	case sql.LevelDefault, sql.LevelSerializable:
+		// Supported
+	default:
+		return ErrIsolationLevelNotSupported{Level: isolation}
+	}
+
+	// Check read-only mode. dqlite does not support read-only transactions.
+	if opts.ReadOnly {
+		return ErrReadOnlyNotSupported{}
+	}
+
+	return nil
+}

--- a/driver/tx_options_test.go
+++ b/driver/tx_options_test.go
@@ -1,0 +1,113 @@
+package driver
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTxOptions_Default(t *testing.T) {
+	opts := driver.TxOptions{}
+	err := ValidateTxOptions(opts)
+	assert.NoError(t, err)
+}
+
+func TestValidateTxOptions_LevelDefault(t *testing.T) {
+	opts := driver.TxOptions{Isolation: driver.IsolationLevel(sql.LevelDefault)}
+	err := ValidateTxOptions(opts)
+	assert.NoError(t, err)
+}
+
+func TestValidateTxOptions_LevelSerializable(t *testing.T) {
+	opts := driver.TxOptions{Isolation: driver.IsolationLevel(sql.LevelSerializable)}
+	err := ValidateTxOptions(opts)
+	assert.NoError(t, err)
+}
+
+func TestValidateTxOptions_LevelReadUncommitted(t *testing.T) {
+	opts := driver.TxOptions{Isolation: driver.IsolationLevel(sql.LevelReadUncommitted)}
+	err := ValidateTxOptions(opts)
+
+	assert.Error(t, err)
+	var isoErr ErrIsolationLevelNotSupported
+	assert.True(t, errors.As(err, &isoErr))
+	assert.Equal(t, sql.LevelReadUncommitted, isoErr.Level)
+	assert.Contains(t, err.Error(), "Read Uncommitted")
+}
+
+func TestValidateTxOptions_LevelReadCommitted(t *testing.T) {
+	opts := driver.TxOptions{Isolation: driver.IsolationLevel(sql.LevelReadCommitted)}
+	err := ValidateTxOptions(opts)
+
+	assert.Error(t, err)
+	var isoErr ErrIsolationLevelNotSupported
+	assert.True(t, errors.As(err, &isoErr))
+	assert.Equal(t, sql.LevelReadCommitted, isoErr.Level)
+}
+
+func TestValidateTxOptions_LevelRepeatableRead(t *testing.T) {
+	opts := driver.TxOptions{Isolation: driver.IsolationLevel(sql.LevelRepeatableRead)}
+	err := ValidateTxOptions(opts)
+
+	assert.Error(t, err)
+	var isoErr ErrIsolationLevelNotSupported
+	assert.True(t, errors.As(err, &isoErr))
+	assert.Equal(t, sql.LevelRepeatableRead, isoErr.Level)
+}
+
+func TestValidateTxOptions_LevelSnapshot(t *testing.T) {
+	opts := driver.TxOptions{Isolation: driver.IsolationLevel(sql.LevelSnapshot)}
+	err := ValidateTxOptions(opts)
+
+	assert.Error(t, err)
+	var isoErr ErrIsolationLevelNotSupported
+	assert.True(t, errors.As(err, &isoErr))
+	assert.Equal(t, sql.LevelSnapshot, isoErr.Level)
+}
+
+func TestValidateTxOptions_LevelLinearizable(t *testing.T) {
+	opts := driver.TxOptions{Isolation: driver.IsolationLevel(sql.LevelLinearizable)}
+	err := ValidateTxOptions(opts)
+
+	assert.Error(t, err)
+	var isoErr ErrIsolationLevelNotSupported
+	assert.True(t, errors.As(err, &isoErr))
+	assert.Equal(t, sql.LevelLinearizable, isoErr.Level)
+}
+
+func TestValidateTxOptions_ReadOnly(t *testing.T) {
+	opts := driver.TxOptions{ReadOnly: true}
+	err := ValidateTxOptions(opts)
+
+	assert.Error(t, err)
+	var roErr ErrReadOnlyNotSupported
+	assert.True(t, errors.As(err, &roErr))
+	assert.Contains(t, err.Error(), "read-only")
+}
+
+func TestValidateTxOptions_ReadOnlyWithSerializable(t *testing.T) {
+	opts := driver.TxOptions{
+		Isolation: driver.IsolationLevel(sql.LevelSerializable),
+		ReadOnly:  true,
+	}
+	err := ValidateTxOptions(opts)
+
+	assert.Error(t, err)
+	var roErr ErrReadOnlyNotSupported
+	assert.True(t, errors.As(err, &roErr))
+}
+
+func TestValidateTxOptions_UnsupportedIsolationCheckedFirst(t *testing.T) {
+	opts := driver.TxOptions{
+		Isolation: driver.IsolationLevel(sql.LevelReadCommitted),
+		ReadOnly:  true,
+	}
+	err := ValidateTxOptions(opts)
+
+	assert.Error(t, err)
+	var isoErr ErrIsolationLevelNotSupported
+	assert.True(t, errors.As(err, &isoErr))
+}


### PR DESCRIPTION
The `database/sql/driver.ConnBeginTx` interface requires drivers to validate transaction options and return errors for unsupported configurations. 

currently, BeginTx would silently accept any isolation level or read-only setting and just run BEGIN, which might be misleading.

the implementation returns `ErrIsolationLevelNotSupported` for anything other than `LevelDefault` or `LevelSerializable` (since SQLite/dqlite only supports serializable), and returns `ErrReadOnlyNotSupported` for read-only transactions (not supported by dqlite). Both error types are exported so callers can check what went wrong with `error.As`.

Closes https://github.com/canonical/go-dqlite/issues/266